### PR TITLE
Make codecov informative; not blocking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        # threshold: 3%  # Allows up to a 3% decrease in total coverage
+    patch:
+      default:
+        informational: true
+        # threshold: 3%  # Allows up to a 3% decrease in patch coverage


### PR DESCRIPTION
This PR makes it so codecov never blocks a PR, it just gives us the useful info about how the PR affects the code. I think that going for specific numbers in a PR is kind of a vanity metric and doesn't actually reflect the state of the codebase. 

i think codecov is most useful which used an informational tool and not something we have to fight against since ultimately it doesnt reflect the validity of the program and is just a guide