### PR TITLE
Test cache improvements

### DIFF
--- a/.github/workflows/geoconnex_e2e.yml
+++ b/.github/workflows/geoconnex_e2e.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           context: .
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=internetofwater/nabu:buildcache
+          cache-to: type=registry,ref=internetofwater/nabu:buildcache,mode=max
           tags: internetofwater/nabu:${{ env.tag }}
 
       - name: "Run Geoconnex Scheduler to simulate a full crawl"

--- a/makefile
+++ b/makefile
@@ -43,5 +43,6 @@ slowest:
 	gotestsum --jsonfile /tmp/json.log
 	gotestsum tool slowest --jsonfile /tmp/json.log
 
+# Check for max tcp connections to ensure no throttling
 checkMaxTcpConnectionsPerProcess:
 	ulimit -n 


### PR DESCRIPTION
- upload all docker cache artifacts to a stable cache image
-  this allows us to reuse the cache across prs since previously we were using the pr tag which only allows for caching commits with the same pr

This cuts down the geoconnex e2e from 7 minutes down to around 1.5 minutes 