### PR TITLE
Add semantic tokens setting to vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,8 @@
     "gopls": {
         // Make local paths have intellisense relative to the
         // project's internal files, not remote docs 
-        "ui.navigation.importShortcut": "Definition"
+        "ui.navigation.importShortcut": "Definition",
+        "ui.semanticTokens": true,
     },
-    "rust-analyzer.cargo.buildScripts.rebuildOnSave": true
+    "rust-analyzer.cargo.buildScripts.rebuildOnSave": true,
 }


### PR DESCRIPTION
add a simple setting to improve syntax highlighting on go code in vscode