### PR TITLE
Clean up prefix code to only use one prefix at a time

### DIFF
--- a/cmd/nabu/prefix.go
+++ b/cmd/nabu/prefix.go
@@ -10,20 +10,12 @@ import (
 	"github.com/internetofwater/nabu/internal/synchronizer"
 )
 
-type PrefixCmd struct{}
+type UploadCmd struct{}
 
-func prefix(cfgStruct config.NabuConfig) error {
+func upload(cfgStruct config.NabuConfig) error {
 	client, err := synchronizer.NewSynchronizerClientFromConfig(cfgStruct)
 	if err != nil {
 		return err
 	}
-
-	for _, prefix := range cfgStruct.Prefixes {
-		// sync without removal is the same as copying an entire prefix
-		err = client.SyncTriplestoreGraphs(context.Background(), prefix, false)
-		if err != nil {
-			return err
-		}
-	}
-	return err
+	return client.SyncTriplestoreGraphs(context.Background(), cfgStruct.Prefix, false)
 }

--- a/cmd/nabu/release.go
+++ b/cmd/nabu/release.go
@@ -15,13 +15,5 @@ func release(cfgStruct config.NabuConfig) error {
 	if err != nil {
 		return err
 	}
-
-	for _, prefix := range cfgStruct.Prefixes {
-		err = client.GenerateNqRelease(prefix)
-		if err != nil {
-			return err
-		}
-	}
-
-	return err
+	return client.GenerateNqRelease(cfgStruct.Prefix)
 }

--- a/cmd/nabu/sync.go
+++ b/cmd/nabu/sync.go
@@ -20,11 +20,5 @@ func Sync(ctx context.Context, cfgStruct config.NabuConfig) error {
 	if err != nil {
 		return err
 	}
-	for _, prefix := range cfgStruct.Prefixes {
-		err = client.SyncTriplestoreGraphs(ctx, prefix, true)
-		if err != nil {
-			return err
-		}
-	}
-	return err
+	return client.SyncTriplestoreGraphs(ctx, cfgStruct.Prefix, true)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,7 @@ type NabuConfig struct {
 	Sparql            SparqlConfig
 	Context           ContextConfig
 	PrefixToFileCache map[string]string
-	Prefixes          []string
+	Prefix            string
 	Trace             bool
 }
 


### PR DESCRIPTION
Multiple prefixes inside the same nabu command is probably a bad thing to do and we never use multiple prefixes in the pipeline anyways;  so removing this;

it is better to spawn two concurrent jobs in dagster if we want to separate prefixes in the pipeline