### PR TITLE
Function for reading from s3 concurrently and concating to disk

### DIFF
--- a/cmd/nabu/main.go
+++ b/cmd/nabu/main.go
@@ -31,8 +31,9 @@ type SyncCmd struct{}
 type TestCmd struct{}
 type ReleaseCmd struct{}
 type ClearCmd struct{}
-
-// type MergeCmd struct{}
+type ConcatCmd struct {
+	OutputFile string `arg:"positional"`
+}
 
 type NabuArgs struct {
 	// Subcommands that can be run
@@ -43,7 +44,7 @@ type NabuArgs struct {
 	Sync    *SyncCmd    `arg:"subcommand:sync" help:"sync the triplestore with the s3 bucket"`
 	Test    *TestCmd    `arg:"subcommand:test" help:"test the connection to the s3 bucket"`
 	Harvest *HarvestCmd `arg:"subcommand:harvest" help:"harvest sitemaps and store them in the s3 bucket"`
-	// Merge   *MergeCmd   `arg:"subcommand:merge" help:"merge all graphs under a prefix into a single graph"`
+	Concat  *ConcatCmd  `arg:"subcommand:concat" help:"merge all graphs under a prefix into a single graph"`
 
 	// Flags that can be set for config particular services / operations
 	config.MinioConfig
@@ -167,6 +168,8 @@ func (n NabuRunner) Run(ctx context.Context) (harvestReport pkg.SitemapIndexCraw
 		return nil, Test(ctx, synchronizerClient)
 	case n.args.Harvest != nil:
 		return Harvest(ctx, cfgStruct.Minio, *n.args.Harvest)
+	case n.args.Concat != nil:
+		return nil, synchronizerClient.S3Client.ConcatToDisk(ctx, cfgStruct.Prefix, n.args.Concat.OutputFile)
 	default:
 		return nil, fmt.Errorf("unknown nabu subcommand")
 	}

--- a/internal/synchronizer/client_object_upload.go
+++ b/internal/synchronizer/client_object_upload.go
@@ -193,8 +193,9 @@ func (synchronizer *SynchronizerClient) GenerateNqRelease(prefix s3.S3Prefix) er
 		// once the nqChan is closed we can close the pipe
 		// since there is nothing more to write
 		defer func() {
-			err = pipeWriter.Close()
-			log.Error(err)
+			if err = pipeWriter.Close(); err != nil {
+				log.Error(err)
+			}
 		}()
 
 		for nq := range nqChan {


### PR DESCRIPTION
- create a function that reads multiple s3 objects in parallel and streams them directly to a file with buffering.
    - this is useful for large release graphs where we can't fit them in memory but need to get them on disk for the purpose of building the knowledge graph index 
- clean up some other tests that were writing and checking against the root prefix; this isn't a good practice for concurrent testing 

To test run

```
time go run ./cmd/nabu/ concat out.txt --prefix graphs/ --log-level DEBUG --s3-access-key YOURS_HERE  --s3-secret-key YOURS_HERE  --bucket harvest-geoconnex-us  --port 443 --address storage.googleapis.com --ssl
```