### PR TITLE
Separate commands for pulling with concat or pulling as separate files

### DIFF
--- a/cmd/nabu/main.go
+++ b/cmd/nabu/main.go
@@ -31,8 +31,9 @@ type SyncCmd struct{}
 type TestCmd struct{}
 type ReleaseCmd struct{}
 type ClearCmd struct{}
-type ConcatCmd struct {
+type PullCmd struct {
 	OutputFile string `arg:"positional"`
+	Concat     bool   `arg:"--concat" help:"concatenate all objects under a prefix into a single file"`
 }
 
 type NabuArgs struct {
@@ -44,7 +45,7 @@ type NabuArgs struct {
 	Sync    *SyncCmd    `arg:"subcommand:sync" help:"sync the triplestore with the s3 bucket"`
 	Test    *TestCmd    `arg:"subcommand:test" help:"test the connection to the s3 bucket"`
 	Harvest *HarvestCmd `arg:"subcommand:harvest" help:"harvest sitemaps and store them in the s3 bucket"`
-	Concat  *ConcatCmd  `arg:"subcommand:concat" help:"merge all graphs under a prefix into a single graph"`
+	Pull    *PullCmd    `arg:"subcommand:pull" help:"pull all objects under a specific prefix in the s3 bucket"`
 
 	// Flags that can be set for config particular services / operations
 	config.MinioConfig
@@ -168,8 +169,8 @@ func (n NabuRunner) Run(ctx context.Context) (harvestReport pkg.SitemapIndexCraw
 		return nil, Test(ctx, synchronizerClient)
 	case n.args.Harvest != nil:
 		return Harvest(ctx, cfgStruct.Minio, *n.args.Harvest)
-	case n.args.Concat != nil:
-		return nil, synchronizerClient.S3Client.ConcatToDisk(ctx, cfgStruct.Prefix, n.args.Concat.OutputFile)
+	case n.args.Pull != nil:
+		return nil, synchronizerClient.S3Client.Pull(ctx, cfgStruct.Prefix, n.args.Pull.OutputFile, n.args.Pull.Concat)
 	default:
 		return nil, fmt.Errorf("unknown nabu subcommand")
 	}

--- a/cmd/nabu/main.go
+++ b/cmd/nabu/main.go
@@ -170,7 +170,7 @@ func (n NabuRunner) Run(ctx context.Context) (harvestReport pkg.SitemapIndexCraw
 	case n.args.Harvest != nil:
 		return Harvest(ctx, cfgStruct.Minio, *n.args.Harvest)
 	case n.args.Pull != nil:
-		return nil, synchronizerClient.S3Client.Pull(ctx, cfgStruct.Prefix, n.args.Pull.OutputFile, n.args.Pull.Concat)
+		return nil, synchronizerClient.S3Client.Pull(ctx, cfgStruct.Prefix, n.args.Pull.OutputFile)
 	default:
 		return nil, fmt.Errorf("unknown nabu subcommand")
 	}

--- a/internal/synchronizer/s3/buffer_helpers.go
+++ b/internal/synchronizer/s3/buffer_helpers.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Lincoln Institute of Land Policy
+// SPDX-License-Identifier: Apache-2.0
+
+package s3
+
+import (
+	"context"
+	"io"
+
+	"github.com/minio/minio-go/v7"
+	log "github.com/sirupsen/logrus"
+)
+
+// a chunk of bytes that can be passed between channels
+type chunk struct {
+	data []byte
+	err  error
+}
+
+const FourMB = 1024 * 1024 * 4
+
+// Download a single object and write it to a channel; return the size of the object
+func getObjAndWriteToChannel(ctx context.Context, m *MinioClientWrapper, obj *minio.ObjectInfo, ch chan<- chunk) (int64, error) {
+	log.Debugf("Downloading %s of size %0.2fMB", obj.Key, float64(obj.Size)/(1024*1024))
+	ob, err := m.Client.GetObject(ctx, m.DefaultBucket, obj.Key, minio.GetObjectOptions{})
+	if err != nil {
+		return 0, err
+	}
+	defer ob.Close()
+	buf := make([]byte, FourMB)
+	for {
+		// read up to the size of the buffer
+		n, err := ob.Read(buf)
+		if n > 0 {
+			// Copy the data to a new slice to avoid data race
+			// this is since bytes are a reference type and
+			// thus to pass this data to another goroutine
+			// could cause a data race
+			dataCopy := make([]byte, n)
+			copy(dataCopy, buf[:n])
+			ch <- chunk{data: dataCopy, err: nil}
+		}
+		// at the end of the file return
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			ch <- chunk{err: err}
+			break
+		}
+	}
+	return obj.Size, nil
+}

--- a/internal/synchronizer/s3/client_test.go
+++ b/internal/synchronizer/s3/client_test.go
@@ -288,38 +288,56 @@ func (suite *S3ClientSuite) TestCRUD() {
 	suite.Require().False(exists)
 }
 
-func (suite *S3ClientSuite) TestConcat() {
-
-	tmpFile, err := os.CreateTemp("", "concat")
-	suite.Require().NoError(err)
-	defer func() {
-		err = os.Remove(tmpFile.Name())
-		suite.Require().NoError(err)
-	}()
+func (suite *S3ClientSuite) TestPull() {
 
 	var data []string
 	const prefix = "concat_test"
 
+	// insert 100 data points
 	for i := range 100 {
 		dataPoint := fmt.Sprintf("test data %d", i)
 		data = append(data, dataPoint)
-		err = suite.minioContainer.ClientWrapper.Store(fmt.Sprintf("%s/%d", prefix, i), bytes.NewReader([]byte(dataPoint)))
+		err := suite.minioContainer.ClientWrapper.Store(fmt.Sprintf("%s/%d", prefix, i), bytes.NewReader([]byte(dataPoint)))
 		suite.Require().NoError(err)
 	}
 
-	err = suite.minioContainer.ClientWrapper.ConcatToDisk(context.Background(), prefix, tmpFile.Name())
-	suite.Require().NoError(err)
+	suite.T().Run("concat to a single file", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "concat")
+		suite.Require().NoError(err)
+		defer func() {
+			err = os.Remove(tmpFile.Name())
+			suite.Require().NoError(err)
+		}()
+		err = suite.minioContainer.ClientWrapper.Pull(context.Background(), prefix, tmpFile.Name(), true)
+		suite.Require().NoError(err)
 
-	concatData, err := os.ReadFile(tmpFile.Name())
-	suite.Require().NoError(err)
+		concatData, err := os.ReadFile(tmpFile.Name())
+		suite.Require().NoError(err)
 
-	concatAsString := string(concatData)
+		concatAsString := string(concatData)
 
-	for _, dataPoint := range data {
-		suite.Require().Contains(concatAsString, dataPoint)
-	}
-	// clean up
-	err = suite.minioContainer.ClientWrapper.Remove(prefix)
+		for _, dataPoint := range data {
+			suite.Require().Contains(concatAsString, dataPoint)
+		}
+	})
+
+	suite.T().Run("pull to a dir", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "concat-*")
+		tmpDir = tmpDir + "/"
+		suite.Require().NoError(err)
+		err = suite.minioContainer.ClientWrapper.Pull(context.Background(), prefix, tmpDir, false)
+		suite.Require().NoError(err)
+
+		files, err := os.ReadDir(tmpDir)
+		suite.Require().NoError(err)
+		for _, file := range files {
+			fileData, err := os.ReadFile(filepath.Join(tmpDir, file.Name()))
+			suite.Require().NoError(err)
+			suite.Require().Contains(string(fileData), file.Name())
+		}
+
+	})
+	err := suite.minioContainer.ClientWrapper.Remove(prefix)
 	suite.Require().NoError(err)
 }
 


### PR DESCRIPTION
When constructing a final data artifact it makes sense to sometimes pull each nq file as a separately directory and other times to concat them all together;

this PR allows for both depending on whether or not the destination ends with `/`; it ends with `/` signifying it is directory, all the files will be downloaded in parallel separately; but if it is not a directory and is instead one file for the destination, we write with concatenation to the same file so produce one huge nq artifact.