### PR TITLE
Jsonld support

### DIFF
--- a/crawl-status-page/src/App.tsx
+++ b/crawl-status-page/src/App.tsx
@@ -7,9 +7,11 @@ import { useEffect, useState } from "react";
 import styles from "./CrawlStatusDashboard.module.css";
 import type { SitemapCrawlStats, SitemapIndexCrawlStats } from "./types";
 import { get_s3_bucket, get_s3_client } from "./env";
+import { make_jsonld } from "./lib";
 
 const CrawlStatusDashboard = () => {
   const [data, setData] = useState<SitemapIndexCrawlStats>([]);
+  const [jsonldData, setJsonldData] = useState<object | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const client = get_s3_client();
@@ -26,28 +28,25 @@ const CrawlStatusDashboard = () => {
         const sitemapcrawlstats: SitemapCrawlStats[] = [];
 
         for (const obj of response.Contents ?? []) {
-          // return early if component is unmounted
-          if (!isMounted) return; 
+          if (!isMounted) return;
           if (obj.Key?.endsWith(".json")) {
             try {
               const objectData = await client.getObject({
-                Bucket:  get_s3_bucket(),
+                Bucket: get_s3_bucket(),
                 Key: obj.Key,
               });
 
               const lastModified = objectData.LastModified;
-
               const body = await objectData.Body?.transformToString();
               if (!body) {
-                if (!isMounted) {
-                  return
-                }
+                if (!isMounted) return;
                 setError(`No body for object ${obj.Key}`);
-                return
+                return;
               }
+
               const json = JSON.parse(body) as SitemapCrawlStats;
               json.LastModified = lastModified
-                ? lastModified.toDateString()
+                ? lastModified.toISOString()
                 : "Unknown";
               sitemapcrawlstats.push(json);
             } catch (e) {
@@ -55,8 +54,11 @@ const CrawlStatusDashboard = () => {
             }
           }
         }
+
         if (isMounted) {
           setData(sitemapcrawlstats);
+          const jsonld = make_jsonld(sitemapcrawlstats);
+          if (isMounted) setJsonldData(jsonld);
           setLoading(false);
         }
       } catch (err: unknown) {
@@ -76,38 +78,64 @@ const CrawlStatusDashboard = () => {
   if (loading) return <div>Loading crawl status...</div>;
   if (error) return <div>Error loading data: {error}</div>;
 
+  const downloadBlob = (data: object) =>
+    URL.createObjectURL(
+      new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      })
+    );
+
   return (
     <>
       <div className={styles.headerRow}>
         <a href="https://docs.geoconnex.us">
-        <img
-          src="/src/assets/geoconnex-logo.png"
-          style={{
-            scale: "0.6",
-            filter: "drop-shadow(0 0 3px white)", // white glow
-          }}
-        />
+          <img
+            src="/src/assets/geoconnex-logo.png"
+            style={{
+              scale: "0.6",
+              filter: "drop-shadow(0 0 3px white)",
+            }}
+          />
         </a>
         <h1 className={styles.h1}>Geoconnex Crawl Status Dashboard</h1>
-        <a
-          href={URL.createObjectURL(
-            new Blob([JSON.stringify(data, null, 2)], {
-              type: "application/json",
-            })
+        <div className={styles.downloadButtonsRow}>
+          <a
+            href={downloadBlob(data)}
+            className={styles.downloadButton}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) =>
+              setTimeout(() => {
+                URL.revokeObjectURL(
+                  (e.currentTarget as HTMLAnchorElement).href
+                );
+              }, 1000)
+            }
+          >
+            View as JSON
+          </a>
+
+          {jsonldData && (
+            <a
+              href={downloadBlob(jsonldData)}
+              className={styles.downloadButton}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) =>
+                setTimeout(() => {
+                  URL.revokeObjectURL(
+                    (e.currentTarget as HTMLAnchorElement).href
+                  );
+                }, 1000)
+              }
+            >
+              View as JSON-LD
+            </a>
           )}
-          className={styles.downloadButton}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => {
-            // Optional: revoke the object URL after opening
-            setTimeout(() => {
-              URL.revokeObjectURL((e.currentTarget as HTMLAnchorElement).href);
-            }, 1000);
-          }}
-        >
-          View as JSON
-        </a>
+        </div>
       </div>
+
+      <ServiceStatusList  />
 
       {data.map((sitemap) => (
         <div key={sitemap.SitemapName} className={styles.sitemap}>

--- a/crawl-status-page/src/CrawlStatusDashboard.module.css
+++ b/crawl-status-page/src/CrawlStatusDashboard.module.css
@@ -114,7 +114,7 @@ a:hover {
 .downloadButton {
     background-color: var(--primary);
     color: white;
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0.5rem;
     text-decoration: none;
     border-radius: 4px;
     float: right;
@@ -130,4 +130,11 @@ a:hover {
     justify-content: space-between;
     gap: 1.5rem;
     margin-bottom: 0.5rem;
+}
+
+.downloadButtonsRow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
 }

--- a/crawl-status-page/src/lib.ts
+++ b/crawl-status-page/src/lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2025 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+import type { JsonLdReport, SitemapCrawlStats, SitemapIndexCrawlStats } from "./types";
+import vocab from "./vocab.json"
+
+export function make_jsonld(data: SitemapIndexCrawlStats) {
+  const newObj = vocab as JsonLdReport;
+
+  const graphItems: SitemapCrawlStats[] = []
+  for (const graph of data) {
+    const graphItem = {
+      "@id": `http://geoconnex.us/sitemap/${graph.SitemapName}`,
+      ...graph,
+    }
+    graphItems.push(graphItem);
+  }
+  
+  newObj["@graph"] = graphItems;
+
+  return newObj;
+}

--- a/crawl-status-page/src/types.ts
+++ b/crawl-status-page/src/types.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import vocab from "./vocab.json";
+
 // The status of the shacl validation
 type ShaclStatus = "skipped" | "invalid" | "valid";
 
@@ -33,9 +35,19 @@ export interface SitemapCrawlStats {
   // The number of total sites in the sitemap
   SitesInSitemap: number;
 
+  // The id is a unique identifier for the sitemap
+  // that is optional and only set in jsonld
+  "@id"?: string;
 
+  // The last modified date of the sitemap
   LastModified?: string;
 }
 
 // A sitemap index is just a list of sitemaps
 export type SitemapIndexCrawlStats = SitemapCrawlStats[];
+
+type VocabType = typeof vocab
+
+export interface JsonLdReport extends VocabType {
+  "@graph": SitemapIndexCrawlStats,
+};

--- a/crawl-status-page/src/vocab.json
+++ b/crawl-status-page/src/vocab.json
@@ -1,0 +1,25 @@
+{
+    "@context": {
+        "schema": "http://schema.org/",
+        "sh": "http://www.w3.org/ns/shacl#",
+        "http": "http://www.w3.org/2011/http#",
+        "SuccessfulUrls": {
+            "@container": "@set",
+            "@id": "schema:url"
+        } ,
+        "SecondsToComplete": "schema:Duration",
+        "SitemapName": "schema:name",
+        "SitesHarvested": "schema:count",
+        "SitesInSitemap": "schema:count",
+        "CrawlFailures": {
+            "@container": "@set",
+            "@id": "schema:error" 
+        },
+        "Url": "schema:url",
+        "Status": "http:StatusCode",
+        "Message": "schema:error",
+        "ShaclStatus": "sh:Severity",
+        "ShaclErrorMessage": "sh:message",
+        "LastModified": "schema:dateModified"
+    }
+}


### PR DESCRIPTION
Add jsonld export support to the frontend. We generate it using React on the frontend since it allows us to iterate on our vocabulary/ontology work without needing to touch any of the code in Nabu. It is also due to the fact that nabu uploads each sitemap separately (this is so we don't have to have every sitemap in memory for the entire run of the program); so some sort of templating needs to be done to concat each of them into one large jsonld object that represents the entire crawl.

Long term if this becomes an essential part of the crawl status / provenance, we can use next.js and serve the jsonld via an API route. For the time being, it is just the frontend. 