### PR TITLE
Updated dependencies on rudof libraries

### DIFF
--- a/shacl_validator_grpc/Cargo.lock
+++ b/shacl_validator_grpc/Cargo.lock
@@ -341,16 +341,6 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "colored"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
@@ -600,10 +590,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -613,11 +601,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -760,7 +746,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -944,15 +929,15 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri_s"
-version = "0.1.66"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b87b6bbe94a120de8b7e78a8123a78560ea25169e88f592d93ea15c36de94"
+checksum = "921f70c5f37b411128ccbc4365b7e861f17328864a99640e5ffb436375121b9b"
 dependencies = [
  "oxiri",
  "oxrdf",
  "reqwest",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
  "url",
 ]
 
@@ -961,15 +946,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1043,10 +1019,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
+name = "matchers"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1120,6 +1099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.2+3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,15 +1180,16 @@ checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
 name = "oxigraph"
-version = "0.4.10"
+version = "0.5.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8392a1106c790ee51623d49fb921453777ac07d17087d74a4afa9aa0cac8d9a6"
+checksum = "988dce94c77cd118849518d50f4848b0d9b1225e27401381f468518fd2b286db"
 dependencies = [
  "dashmap",
  "getrandom 0.2.16",
@@ -1200,13 +1198,13 @@ dependencies = [
  "oxrdf",
  "oxrdfio",
  "oxsdatatypes",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "siphasher",
  "sparesults",
  "spareval",
  "spargebra",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1226,53 +1224,53 @@ checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
 
 [[package]]
 name = "oxjsonld"
-version = "0.1.0"
+version = "0.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a1a66dc569350f3f4e5eff8a8e1a72b0c9e6ad395bb5805493cb7a2fda185f"
+checksum = "e1b78280dcd718256241448d7d2d154297932edf3e65d357dae91296f9c442e5"
 dependencies = [
  "json-event-parser",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
 name = "oxrdf"
-version = "0.2.4"
+version = "0.3.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04761319ef84de1f59782f189d072cbfc3a9a40c4e8bded8667202fbd35b02a"
+checksum = "c3ebc0d1c28af28e0a98ec101270dccccffa06e0d3a12cab2cfc4f3fdad08a5c"
 dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.8.5",
- "thiserror 2.0.12",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
 name = "oxrdfio"
-version = "0.1.8"
+version = "0.2.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d33dd87769786a0bb7de342865e33bf0c6e9872fa76f1ede23e944fdc77898"
+checksum = "d48af50dc7600819a8d182ebae4cfcbc9796004fd64772f5ca8a49eecab7a454"
 dependencies = [
  "oxjsonld",
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
 name = "oxrdfxml"
-version = "0.1.7"
+version = "0.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d4bf9c5331127f01efbd1245d90fd75b7c546a97cb3e95461121ce1ad5b1c8"
+checksum = "60296479cf47f5d6df6af3c8a4e82d517424f15b1978783e5c6110495c1086dd"
 dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
  "quick-xml",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1281,20 +1279,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
 name = "oxttl"
-version = "0.1.8"
+version = "0.2.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d385f1776d7cace455ef6b7c54407838eff902ca897303d06eb12a26f4cf8a0"
+checksum = "da40f5891e8f11d64035c33e8497c32b3fb99ace7e9b99d3d20fec1f745742b7"
 dependencies = [
  "memchr",
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1411,15 +1409,15 @@ dependencies = [
 
 [[package]]
 name = "prefixmap"
-version = "0.1.64"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92852cdb18875e1f8f868194be871ad49b6511f843379001e3194a5f620a6e2b"
+checksum = "55308742127ec87d91eb902dd1ec58d275f3d91ab3ca50d610f5f1a12629e80b"
 dependencies = [
- "colored 3.0.0",
+ "colored",
  "indexmap",
  "iri_s",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1467,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -1487,7 +1485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -1532,61 +1530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
-dependencies = [
- "bytes",
- "getrandom 0.3.3",
- "lru-slab",
- "rand 0.9.1",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.12",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,18 +1557,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1635,17 +1568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1655,15 +1578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1741,10 +1655,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1752,14 +1663,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -1816,7 +1725,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -1864,7 +1773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1886,7 +1794,6 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2011,19 +1918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,28 +1941,65 @@ dependencies = [
 
 [[package]]
 name = "shacl_ast"
-version = "0.1.63"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58000f1088fd203b0b16adb16edb6f2b4c8886bade95a262671bf63b0247bb80"
+checksum = "273812a77c6895aabc593eae1373a004bd7cfacc5a1ca26cf4c306a99c7c49be"
 dependencies = [
  "const_format",
  "iri_s",
- "itertools 0.14.0",
+ "itertools",
+ "oxrdf",
+ "prefixmap",
+ "regex",
+ "srdf",
+ "thiserror",
+]
+
+[[package]]
+name = "shacl_ir"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec67f475b9ea5dea3ca274240b8adb1a6cda88ff8680790f6cf6c0d6b051fae"
+dependencies = [
+ "iri_s",
+ "itertools",
+ "oxrdf",
+ "prefixmap",
+ "regex",
+ "shacl_ast",
+ "shacl_rdf",
+ "srdf",
+ "thiserror",
+]
+
+[[package]]
+name = "shacl_rdf"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b842c0842800ae2a065f8f88ed6afdfea5012ad873c4a4a7f52c5fd77db14a"
+dependencies = [
+ "const_format",
+ "iri_s",
+ "itertools",
  "lazy_static",
  "oxrdf",
  "prefixmap",
+ "regex",
+ "shacl_ast",
  "srdf",
- "thiserror 2.0.12",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "shacl_validation"
-version = "0.1.63"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9557149a33d8127c84bfa0fb0cf9cec3ae74e7aa59579e1c91e60af46e071c"
+checksum = "360f57c8e763eeb7ecf793ce6013c2ba38e36c3eecb9b00d110f3a967e2a274f"
 dependencies = [
+ "anyhow",
  "clap",
- "colored 3.0.0",
+ "colored",
  "const_format",
  "indoc",
  "iri_s",
@@ -2076,10 +2007,14 @@ dependencies = [
  "prefixmap",
  "serde",
  "shacl_ast",
+ "shacl_ir",
+ "shacl_rdf",
  "sparql_service",
  "srdf",
- "thiserror 2.0.12",
+ "thiserror",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2088,6 +2023,7 @@ version = "0.1.0"
 dependencies = [
  "prost",
  "shacl_ast",
+ "shacl_ir",
  "shacl_validation",
  "sparql_service",
  "srdf",
@@ -2095,6 +2031,15 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2151,22 +2096,22 @@ dependencies = [
 
 [[package]]
 name = "sparesults"
-version = "0.2.5"
+version = "0.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f478f5ead16b6136bccee7a52ea43a615f8512086708f515e26ce33e0b184036"
+checksum = "e7d2b4924de8a3ac214423ed0609dfc792da5510f0b7298a501ca00fb1c89590"
 dependencies = [
  "json-event-parser",
  "memchr",
  "oxrdf",
  "quick-xml",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
 name = "spareval"
-version = "0.1.4"
+version = "0.2.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d8ff5f1159e7416ed99160b962fa780851dddee133ef56e6b08a94023ea2c7"
+checksum = "1ad58aad4875fa7febad5fd00944682858886be326f15331cf175137eb2760c3"
 dependencies = [
  "hex",
  "json-event-parser",
@@ -2174,7 +2119,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rustc-hash",
  "sha1",
@@ -2182,44 +2127,44 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
 name = "spargebra"
-version = "0.3.5"
+version = "0.4.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8907e262be4b4b363218f4688f5654d423a958aa4b8d7c7a7f898be591fa474e"
+checksum = "6b3eb3964fd810adf3d9a65d9eacc99822577d13a9c156120562e459c8cc3238"
 dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.8.5",
- "thiserror 2.0.12",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
 name = "sparopt"
-version = "0.2.1"
+version = "0.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790bbdf13560c2afc245ab0f82a489003b3918e668ebd45c65fe46bfd7a1763"
+checksum = "d7063c79b858df005fecf5dcd3add910146a09945c4799c86f3bd7e398432c36"
 dependencies = [
  "oxrdf",
- "rand 0.8.5",
+ "rand",
  "spargebra",
 ]
 
 [[package]]
 name = "sparql_service"
-version = "0.1.60"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faca9849736b8519a9d0d0c142147c71da06df36f7146a6b8e58bd0dfca678ca"
+checksum = "909b83ffdf6d1049f592b982dd058b44037fa934d6e9722e0cca9942494b1e7c"
 dependencies = [
- "colored 2.2.0",
+ "colored",
  "const_format",
  "iri_s",
- "itertools 0.13.0",
+ "itertools",
  "lazy_static",
  "oxigraph",
  "oxrdf",
@@ -2228,26 +2173,27 @@ dependencies = [
  "prefixmap",
  "rust_decimal",
  "serde",
- "serde_yaml_ng",
  "sparesults",
  "srdf",
- "thiserror 1.0.69",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
 name = "srdf"
-version = "0.1.63"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587072176ccdc3a61128f40d91b2f88baeabf03cc570b675dcb31d07affb0fca"
+checksum = "c626f2af7817507bc8229c9760f63ce6c1e52ada554000c79e119b64bd27e435"
 dependencies = [
  "async-trait",
- "colored 3.0.0",
+ "colored",
  "const_format",
  "iri_s",
- "itertools 0.14.0",
+ "itertools",
  "lazy_static",
  "oxilangtag",
  "oxiri",
+ "oxjsonld",
  "oxrdf",
  "oxrdfio",
  "oxrdfxml",
@@ -2260,7 +2206,8 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "sparesults",
- "thiserror 2.0.12",
+ "tempfile",
+ "thiserror",
  "toml",
  "tracing",
  "url",
@@ -2368,31 +2315,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2404,6 +2331,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2647,6 +2583,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2672,12 +2638,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2713,6 +2673,12 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2829,34 +2795,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/shacl_validator_grpc/Cargo.toml
+++ b/shacl_validator_grpc/Cargo.toml
@@ -10,11 +10,12 @@ edition = "2021"
 tonic = "*"
 prost = "0.13"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "signal"] }
-shacl_validation = "0.1.60"
-srdf = "0.1.60"
-sparql_service = "0.1.60"
+shacl_validation = "0.1.80"
+srdf = "0.1.89"
+sparql_service = "0.1.87"
 tokio-stream = "0.1.17"
-shacl_ast = "0.1.63"
+shacl_ast = "0.1.89"
+shacl_ir = "0.1.89"
 
 [build-dependencies]
 tonic-build = "*"

--- a/shacl_validator_grpc/src/lib.rs
+++ b/shacl_validator_grpc/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Lincoln Institute of Land Policy
 // SPDX-License-Identifier: Apache-2.0
 
-use shacl_ast::compiled::schema::SchemaIR;
+use shacl_ir::compiled::schema::SchemaIR;
 use shacl_validation::shacl_processor::{GraphValidation, ShaclProcessor, ShaclValidationMode};
 use shacl_validation::store::graph::Graph;
 use shacl_validation::validate_error::ValidateError;
@@ -24,8 +24,8 @@ use std::io::Cursor;
 /// An empty struct upon which to implement the necessary traits
 /// for our grpc server with tokio and tonic
 pub struct Validator {
-    pub dataset_schema: Arc<SchemaIR<RdfData>>,
-    pub location_schema: Arc<SchemaIR<RdfData>>,
+    pub dataset_schema: Arc<SchemaIR>,
+    pub location_schema: Arc<SchemaIR>,
 }
 
 impl Default for Validator {
@@ -67,10 +67,9 @@ impl Validator {
 
 /// Validate an arbitrary string of rdf triples against a string of shacl shapes.
 pub fn validate_triples(
-    shacl: &SchemaIR<RdfData>,
+    shacl: &SchemaIR,
     triples: &str,
 ) -> Result<ValidationReport, ValidateError> {
-
     let srdf_graph = SRDFGraph::from_str(
         triples,
         &RDFFormat::Turtle,
@@ -177,7 +176,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_empty_triple() {
         // Minimal SHACL shape: ex:Person must have an ex:name property of type xsd:string
@@ -207,7 +205,10 @@ mod tests {
         );
         let report = result.unwrap();
         // this is confusing but appears to be correct vv
-        assert!(report.conforms(), "An empty triple has no nodes to validate and thus is valid");
+        assert!(
+            report.conforms(),
+            "An empty triple has no nodes to validate and thus is valid"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This pull-request updates the dependencies on the rudof libraries as well as the `lib.rs` file so it compiles again.