### PR TITLE
Add csv generation login into shacl validator cli

### DIFF
--- a/shacl_validator/Dockerfile_py
+++ b/shacl_validator/Dockerfile_py
@@ -35,4 +35,4 @@ COPY --from=builder --chown=app:app /app /app
 # Place executables in the environment at the front of the path
 ENV PATH="/app/service/.venv/bin:$PATH"
 
-ENTRYPOINT ["python", "/app/service/server.py"]
+ENTRYPOINT ["python", "/app/service/cli.py"]

--- a/shacl_validator/shacl_validator_grpc_py/cli.py
+++ b/shacl_validator/shacl_validator_grpc_py/cli.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import logging
+from pathlib import Path
+from geoconnex_gen import GeoconnexCSVConfig, generate_geoconnex_csv
+
+# Import validation logic
+from lib import check_jsonld_from_oaf_endpoint, validate_jsonld_from_url
+from server import serve
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def main():
+    """Main entry point for the server."""
+    parser = argparse.ArgumentParser(description="SHACL Validation gRPC Server")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    server_subparser = subparsers.add_parser("serve", help="Start the gRPC server for SHACL validation")
+    server_subparser.add_argument(
+        "--address",
+        type=str,
+        default="0.0.0.0:50051",
+        help="Path to the grpc socket to listen on",
+    )
+    server_subparser.add_argument(
+        "--shacl_file",
+        type=str,
+        default=str(
+            (
+                Path(__file__).parent.parent / "shacl_shapes" / "locationOriented.ttl"
+            ).absolute()
+        ),
+        help="Path to the shacl file to use for validation",
+    )
+
+
+    check_oaf_subparser = subparsers.add_parser("check_oaf", help="Check jsonld from an OGC API-Features endpoint")
+    check_oaf_subparser.add_argument(
+        "--endpoint", type=str, help="OGC API-Features endpoint"
+    )
+    check_oaf_subparser.add_argument(
+        "--collection", type=str, help="OGC API-Features collection"
+    )
+
+    check_url_subparser = subparsers.add_parser("check_url", help="Check jsonld from a single url")
+    check_url_subparser.add_argument("--url", type=str, help="URL to check", required=True)
+    check_url_subparser.add_argument("--watch", action="store_true", help="Loop checking the url", default=False)
+
+    generate_geoconnex_csv_subparser = subparsers.add_parser("generate_geoconnex_csv", help="Generate geoconnex csv from a collection")
+    generate_geoconnex_csv_subparser.add_argument(
+        "--oaf_items_endpoint", type=str, help="The full url to your OGC API-Features collection's items endpoint. Example: https://example.com/api/collections/my_water_data/items", required=True
+    )
+    generate_geoconnex_csv_subparser.add_argument(
+        "--validate_shacl", help="Validate all jsonld items before generating csv", action="store_true", default=False
+    )
+    generate_geoconnex_csv_subparser.add_argument(
+        "--shacl_file", type=str, help="Path to the shacl file to use for validation", required=False, default=str((Path(__file__).parent.parent / "shacl_shapes" / "locationOriented.ttl").absolute())
+    )
+    generate_geoconnex_csv_subparser.add_argument(
+        "--description", type=str, help="Description for the geoconnex csv", default="", required=True 
+    )
+    generate_geoconnex_csv_subparser.add_argument(
+        "--contact_email", type=str, help="Contact email for the csv submissions", required=True, default=""
+    )
+    generate_geoconnex_csv_subparser.add_argument(
+        "--geoconnex_namespace", type=str, help="Namespace for the geoconnex csv. Example: wwdh/usace", required=True
+    )
+    
+
+    args = parser.parse_args()
+
+    if args.command == "check_oaf":
+        check_jsonld_from_oaf_endpoint(args.endpoint, args.collection)
+    elif args.command == "check_url":
+        validate_jsonld_from_url(args.url, watch=args.watch)
+    elif args.command == "generate_geoconnex_csv":
+        generate_geoconnex_csv(
+            GeoconnexCSVConfig(
+                oaf_items_endpoint=args.oaf_items_endpoint,
+                description=args.description,
+                contact_email=args.contact_email,
+                shacl_shape=args.shacl_file,
+                check_shacl=args.validate_shacl,
+                geoconnex_namespace=args.geoconnex_namespace,
+            )
+        )
+    else:
+        logger.info(f"Starting SHACL Validation Server on {args.socket}")
+        logger.info(f"SHACL file used for validation: {args.shacl}")
+        serve(socket_path=args.address)
+
+
+if __name__ == "__main__":
+    main()

--- a/shacl_validator/shacl_validator_grpc_py/geoconnex_gen.py
+++ b/shacl_validator/shacl_validator_grpc_py/geoconnex_gen.py
@@ -26,7 +26,7 @@ def generate_geoconnex_csv(config: GeoconnexCSVConfig):
     collection_resp.raise_for_status()
     collection = collection_resp.json()
 
-    csv_header = ["id", "target", "creator", "description"]
+    csv_header_row = ["id", "target", "creator", "description"]
     csv_rows = []
 
     if config.check_shacl:
@@ -50,6 +50,8 @@ def generate_geoconnex_csv(config: GeoconnexCSVConfig):
 
             if not conforms:
                 raise Exception(f"SHACL Validation failed for {jsonld_url}: \n{text}")
+            
+            print(f"SHACL Validation passed for {jsonld_url}")
 
         csv_rows.append(
             [f"https://geoconnex.us/{config.geoconnex_namespace}/{feature_id}", feature_url, config.contact_email, config.description]
@@ -58,7 +60,7 @@ def generate_geoconnex_csv(config: GeoconnexCSVConfig):
     output_path = Path("geoconnex.csv")
     with open(output_path.absolute(), "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
-        writer.writerow(csv_header)
+        writer.writerow(csv_header_row)
         writer.writerows(csv_rows)
 
     print(f"CSV written to {output_path.absolute()}")

--- a/shacl_validator/shacl_validator_grpc_py/server.py
+++ b/shacl_validator/shacl_validator_grpc_py/server.py
@@ -8,13 +8,14 @@ and provides SHACL validation services.
 """
 
 import logging
-import argparse
 from concurrent import futures
-from pathlib import Path
 import grpc
 from rdflib import Graph
-from geoconnex_gen import GeoconnexCSVConfig, generate_geoconnex_csv
-from shacl_validator_pb2 import JsoldValidationRequest, ValidationReply, LocationOriented
+from shacl_validator_pb2 import (
+    JsoldValidationRequest,
+    ValidationReply,
+    LocationOriented,
+)
 
 from grpc import ServicerContext
 
@@ -22,7 +23,7 @@ from grpc import ServicerContext
 import shacl_validator_pb2_grpc
 
 # Import validation logic
-from lib import check_jsonld_from_oaf_endpoint, validate_graph, validate_jsonld_from_url
+from lib import validate_graph
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -33,7 +34,6 @@ class ShaclValidator(shacl_validator_pb2_grpc.ShaclValidatorServicer):
     def Validate(
         self, request: JsoldValidationRequest, context: ServicerContext
     ) -> ValidationReply:
-        
         jsonld = Graph()
         jsonld.parse(data=request.jsonld, format="json-ld")
         conforms, _, text = validate_graph(jsonld, format="location_oriented")
@@ -64,7 +64,7 @@ def serve(socket_path: str = "0.0.0.0:50051"):
 
     # Start the server
     server.start()
-    logger.info(f"Server started, listening on unix:{socket_path}")
+    logger.info(f"Server started, listening on {socket_path}")
 
     try:
         server.wait_for_termination()
@@ -72,76 +72,3 @@ def serve(socket_path: str = "0.0.0.0:50051"):
         logger.info("Server shutting down...")
         server.stop(0)
         logger.info("Server shut down successfully")
-
-
-def main():
-    """Main entry point for the server."""
-    parser = argparse.ArgumentParser(description="SHACL Validation gRPC Server")
-    parser.add_argument(
-        "--socket",
-        type=str,
-        default="0.0.0.0:50051",
-        help="Path to the grpc socket to listen on",
-    )
-    parser.add_argument(
-        "--shacl",
-        type=str,
-        default=str((Path(__file__).parent.parent / "shacl_shapes" / "locationOriented.ttl").absolute()),
-        help="Path to the shacl file to use for validation",
-    )
-    subparsers = parser.add_subparsers(dest="command", required=False)
-    check_oaf_subparser = subparsers.add_parser("check_oaf", help="Check jsonld from an OGC API-Features endpoint")
-    check_oaf_subparser.add_argument(
-        "--endpoint", type=str, help="OGC API-Features endpoint"
-    )
-    check_oaf_subparser.add_argument(
-        "--collection", type=str, help="OGC API-Features collection"
-    )
-
-    check_url_subparser = subparsers.add_parser("check_url", help="Check jsonld from a single url")
-    check_url_subparser.add_argument("--url", type=str, help="URL to check", required=True)
-    check_url_subparser.add_argument("--watch", action="store_true", help="Loop checking the url", default=False)
-
-    generate_geoconnex_csv_subparser = subparsers.add_parser("generate_geoconnex_csv", help="Generate geoconnex csv from a collection")
-    generate_geoconnex_csv_subparser.add_argument(
-        "--oaf_items_endpoint", type=str, help="The full url to your OGC API-Features collection", required=True
-    )
-    generate_geoconnex_csv_subparser.add_argument(
-        "--validate_shacl", type=bool, help="Validate all jsonld items before generating csv", default=False
-    )
-    generate_geoconnex_csv_subparser.add_argument(
-        "--description", type=str, help="Description for the geoconnex csv", default="", required=True 
-    )
-    generate_geoconnex_csv_subparser.add_argument(
-        "--contact_email", type=str, help="Contact email for the csv submissions", required=True, default=""
-    )
-    generate_geoconnex_csv_subparser.add_argument(
-        "--geoconnex_namespace", type=str, help="Namespace for the geoconnex csv", required=True
-    )
-    
-
-    args = parser.parse_args()
-
-    if args.command == "check_oaf":
-        check_jsonld_from_oaf_endpoint(args.endpoint, args.collection)
-    elif args.command == "check_url":
-        validate_jsonld_from_url(args.url, watch=args.watch)
-    elif args.command == "generate_geoconnex_csv":
-        generate_geoconnex_csv(
-            GeoconnexCSVConfig(
-                oaf_items_endpoint=args.oaf_items_endpoint,
-                description=args.description,
-                contact_email=args.contact_email,
-                shacl_shape=args.shacl,
-                check_shacl=args.validate_shacl,
-                geoconnex_namespace=args.geoconnex_namespace,
-            )
-        )
-    else:
-        logger.info(f"Starting SHACL Validation Server on {args.socket}")
-        logger.info(f"SHACL file used for validation: {args.shacl}")
-        serve(socket_path=args.socket)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
since we already have shacl validation logic it makes sense to couple it with geoconnex csv generation logic. That way a user could validate all their items before making a new geoconnex csv.