### PR TITLE
add a flag to optionally exit fast on shacl failure

### DIFF
--- a/cmd/nabu/harvest.go
+++ b/cmd/nabu/harvest.go
@@ -31,6 +31,7 @@ type HarvestCmd struct {
 	SitemapWorkers        int    `arg:"--sitemap-workers" default:"10"`
 	HeadlessChromeUrl     string `arg:"--headless-chrome-url" default:"0.0.0.0:9222" help:"port for interacting with the headless chrome devtools"`
 	ShaclEndpoint         string `arg:"--shacl-grpc-endpoint" default:"" help:"full shacl grpc endpoint with port to use for validation; if empty skip validation"`
+	ExitOnShaclFailure    bool   `arg:"--exit-on-shacl-failure" default:"false" help:"immediately exit if shacl validation fails"`
 	CleanupOutdatedJsonld bool   `arg:"--cleanup-outdated-jsonld" default:"false" help:"cleanup outdated jsonld files from the bucket"`
 }
 
@@ -67,7 +68,7 @@ func Harvest(ctx context.Context, client *http.Client, minioConfig config.MinioC
 		WithConcurrencyConfig(args.ConcurrentSitemaps, args.SitemapWorkers).
 		WithSpecifiedSourceFilter(args.Source).
 		WithHeadlessChromeUrl(args.HeadlessChromeUrl).
-		WithShaclValidationConfig(args.ShaclEndpoint).
+		WithShaclValidationConfig(args.ShaclEndpoint, args.ExitOnShaclFailure).
 		WithOldJsonldCleanup(args.CleanupOutdatedJsonld).
 		HarvestSitemaps(ctx, client)
 	if err != nil {

--- a/internal/crawl/sitemap_index.go
+++ b/internal/crawl/sitemap_index.go
@@ -36,6 +36,7 @@ type Index struct {
 	headlessChromeUrl       string               `xml:"-"`
 	shaclAddress            string               `xml:"-"`
 	oldJsonldCleanupEnabled bool                 `xml:"-"`
+	exitOnShaclFailure      bool                 `xml:"-"`
 }
 
 // parts is a structure of <sitemap> in <sitemapindex>
@@ -163,7 +164,7 @@ func (i Index) HarvestSitemaps(ctx context.Context, client *http.Client) (pkg.Si
 
 			stats, harvestErr := sitemap.
 				SetStorageDestination(i.storageDestination).
-				Harvest(ctx, client, i.sitemapWorkers, id, i.shaclAddress, i.oldJsonldCleanupEnabled)
+				Harvest(ctx, client, i.sitemapWorkers, id, i.shaclAddress, i.oldJsonldCleanupEnabled, i.exitOnShaclFailure)
 
 			for err := range errChan {
 				if err != nil {
@@ -217,7 +218,7 @@ func (i Index) HarvestSitemap(ctx context.Context, client *http.Client, sitemapI
 			return pkg.SitemapCrawlStats{}, err
 		}
 		return sitemap.SetStorageDestination(i.storageDestination).
-			Harvest(ctx, client, i.sitemapWorkers, id, i.shaclAddress, i.oldJsonldCleanupEnabled)
+			Harvest(ctx, client, i.sitemapWorkers, id, i.shaclAddress, i.oldJsonldCleanupEnabled, i.exitOnShaclFailure)
 	}
 	return pkg.SitemapCrawlStats{}, fmt.Errorf("sitemap %s not found in sitemap", sitemapIdentifier)
 }

--- a/internal/crawl/sitemap_index_config.go
+++ b/internal/crawl/sitemap_index_config.go
@@ -14,8 +14,9 @@ func (i Index) WithStorageDestination(storageDestination storage.CrawlStorage) I
 	return i
 }
 
-func (i Index) WithShaclValidationConfig(shaclAddress string) Index {
+func (i Index) WithShaclValidationConfig(shaclAddress string, exitOnShaclFailure bool) Index {
 	i.shaclAddress = shaclAddress
+	i.exitOnShaclFailure = exitOnShaclFailure
 	return i
 }
 

--- a/internal/crawl/sitemap_index_test.go
+++ b/internal/crawl/sitemap_index_test.go
@@ -126,10 +126,10 @@ func TestHarvestSitemapIndex(t *testing.T) {
 	sitemap, err := NewSitemap(context.Background(), mockedClient, sitemapUrls.GetUrlList()[0])
 	require.NoError(t, err)
 
-	_, errs := sitemap.SetStorageDestination(tmpStore).Harvest(context.Background(), mockedClient, 10, "test", "", false)
+	_, errs := sitemap.SetStorageDestination(tmpStore).Harvest(context.Background(), mockedClient, 10, "test", "", false, true)
 	require.NoError(t, errs)
 
-	_, errs = sitemap.SetStorageDestination(container.ClientWrapper).Harvest(context.Background(), mockedClient, 1, "test", "", false)
+	_, errs = sitemap.SetStorageDestination(container.ClientWrapper).Harvest(context.Background(), mockedClient, 1, "test", "", false, true)
 	require.NoError(t, errs)
 	numObjs, err := container.ClientWrapper.NumberOfMatchingObjects([]string{""})
 	require.NoError(t, err)

--- a/internal/crawl/sitemap_test.go
+++ b/internal/crawl/sitemap_test.go
@@ -40,6 +40,6 @@ func TestHarvestSitemap(t *testing.T) {
 	require.NoError(t, err)
 	_, errs := sitemap.
 		SetStorageDestination(storage.DiscardCrawlStorage{}).
-		Harvest(context.Background(), mockedClient, 10, "test", "", false)
+		Harvest(context.Background(), mockedClient, 10, "test", "", false, true)
 	require.NoError(t, errs)
 }

--- a/internal/crawl/testdata/reference_feature.jsonld
+++ b/internal/crawl/testdata/reference_feature.jsonld
@@ -13,7 +13,7 @@
     "fid": 9635,
     "placefp": "24568",
     "affgeoid": "1600000US0124568",
-    "name": "Eufaula",
+    "schema:name": "Eufaula",
     "census_profile": "https://data.census.gov/cedsci/profile?g=1600000US0124568",
     "placens": "02403575",
     "statefp": "01",


### PR DESCRIPTION
it is useful to have an optional flag to make nabu immediately fail upon find a non compliant jsonld document when harvesting jsonld. 

added this along with an associated test.
