### PR TITLE
Separate metadata bucket

### DIFF
--- a/cmd/nabu/harvest.go
+++ b/cmd/nabu/harvest.go
@@ -57,7 +57,7 @@ func Harvest(ctx context.Context, client *http.Client, minioConfig config.MinioC
 		if err != nil {
 			return nil, err
 		}
-		if err := minioS3.MakeDefaultBucket(); err != nil {
+		if err := minioS3.SetupBuckets(); err != nil {
 			return nil, err
 		}
 		storageDestination = minioS3
@@ -78,7 +78,7 @@ func Harvest(ctx context.Context, client *http.Client, minioConfig config.MinioC
 	if err != nil {
 		return nil, err
 	}
-	if err := storageDestination.Store(fmt.Sprintf("metadata/crawl_stats_%s.json", args.Source), strings.NewReader(asJson)); err != nil {
+	if err := storageDestination.StoreMetadata(fmt.Sprintf("metadata/crawl_stats_%s.json", args.Source), strings.NewReader(asJson)); err != nil {
 		return nil, err
 	}
 

--- a/cmd/nabu/harvest_integration_test.go
+++ b/cmd/nabu/harvest_integration_test.go
@@ -50,6 +50,7 @@ func (s *GleanerInterationSuite) TestIntegrationWithNabu() {
 		&s.graphdbContainer.Client,
 		s.minioContainer.ClientWrapper,
 		s.minioContainer.ClientWrapper.DefaultBucket,
+		s.minioContainer.ClientWrapper.MetadataBucket,
 	)
 
 	s.Require().NoError(err)
@@ -69,11 +70,12 @@ func (suite *GleanerInterationSuite) SetupSuite() {
 	net, err := network.New(ctx)
 	require.NoError(t, err)
 	minioContainer, err := s3.NewMinioContainerFromConfig(s3.MinioContainerConfig{
-		Username:      "minioadmin",
-		Password:      "minioadmin",
-		DefaultBucket: "iow",
-		ContainerName: "integrationTestMinio",
-		Network:       net.Name,
+		Username:       "minioadmin",
+		Password:       "minioadmin",
+		DefaultBucket:  "iow",
+		MetadataBucket: "metadata",
+		ContainerName:  "integrationTestMinio",
+		Network:        net.Name,
 	})
 	suite.Require().NoError(err)
 	suite.minioContainer = minioContainer
@@ -85,7 +87,7 @@ func (suite *GleanerInterationSuite) SetupSuite() {
 		return suite.minioContainer.ClientWrapper.Client.IsOnline()
 	}, 10*time.Second, 500*time.Millisecond, "MinIO container did not become online in time")
 
-	err = suite.minioContainer.ClientWrapper.MakeDefaultBucket()
+	err = suite.minioContainer.ClientWrapper.SetupBuckets()
 	require.NoError(t, err)
 
 	graphdbContainer, err := triplestores.NewGraphDBContainer("iow", "./testdata/iow-config.ttl")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,13 +24,14 @@ type SparqlConfig struct {
 
 // The config for minio/s3 operations
 type MinioConfig struct {
-	Address   string `arg:"--address" help:"The address of the s3 server" default:"127.0.0.1"` // The address of the minio server
-	Port      int    `arg:"--port" default:"9000"`
-	Accesskey string `arg:"--s3-access-key,env:S3_ACCESS_KEY" help:"Access Key (i.e. username)" default:"minioadmin"` // Access Key (i.e. username)
-	Secretkey string `arg:"--s3-secret-key,env:S3_SECRET_KEY" help:"Secret Key (i.e. password)" default:"minioadmin"` // Secret Key (i.e. password)
-	Bucket    string `arg:"--bucket" help:"The s3 bucket to use for sync operations" default:"iow"`                   // The configuration bucket
-	Region    string `arg:"--region" help:"region for the s3 server"`                                                 // region for the minio server
-	SSL       bool   `arg:"--ssl" help:"Use SSL when connecting to s3"`
+	Address        string `arg:"--address" help:"The address of the s3 server" default:"127.0.0.1"` // The address of the minio server
+	Port           int    `arg:"--port" default:"9000"`
+	Accesskey      string `arg:"--s3-access-key,env:S3_ACCESS_KEY" help:"Access Key (i.e. username)" default:"minioadmin"` // Access Key (i.e. username)
+	Secretkey      string `arg:"--s3-secret-key,env:S3_SECRET_KEY" help:"Secret Key (i.e. password)" default:"minioadmin"` // Secret Key (i.e. password)
+	Bucket         string `arg:"--bucket" help:"The s3 bucket to use for sync operations" default:"iow"`                   // The configuration bucket
+	MetadataBucket string `arg:"--metadata-bucket" help:"The s3 bucket to use for storing public metadata" default:"iow-metadata"`
+	Region         string `arg:"--region" help:"region for the s3 server"` // region for the minio server
+	SSL            bool   `arg:"--ssl" help:"Use SSL when connecting to s3"`
 }
 
 // THe config for jsonld context operations

--- a/internal/crawl/sitemap.go
+++ b/internal/crawl/sitemap.go
@@ -230,7 +230,7 @@ func (s Sitemap) Harvest(ctx context.Context, client *http.Client, workers int, 
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = s.storageDestination.Store(fmt.Sprintf("metadata/sitemaps/%s.json", sitemapID), asJson)
+		err = s.storageDestination.StoreMetadata(fmt.Sprintf("metadata/sitemaps/%s.json", sitemapID), asJson)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/crawl/sitemap.go
+++ b/internal/crawl/sitemap.go
@@ -225,16 +225,14 @@ func (s Sitemap) Harvest(ctx context.Context, client *http.Client, workers int, 
 		stats.CrawlFailures = append(stats.CrawlFailures, nonFatalErr)
 	}
 
-	go func() {
-		asJson, err := stats.ToJsonIoReader()
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = s.storageDestination.StoreMetadata(fmt.Sprintf("metadata/sitemaps/%s.json", sitemapID), asJson)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
+	asJson, err := stats.ToJsonIoReader()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = s.storageDestination.StoreMetadata(fmt.Sprintf("metadata/sitemaps/%s.json", sitemapID), asJson)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	log.Debugf("Finished crawling sitemap %s in %f seconds", sitemapID, stats.SecondsToComplete)
 

--- a/internal/crawl/storage/storage.go
+++ b/internal/crawl/storage/storage.go
@@ -40,6 +40,10 @@ func (s Set) Add(key objectPath) {
 
 // A storage interface that stores crawl data
 type CrawlStorage interface {
+	// Store metadata about the crawl into a named destination
+	// This may be in a different place than normal storage since it is intended to be
+	// read publicly and drive UIs
+	StoreMetadata(objectPath, io.Reader) error
 	// Store saves the contents from the reader into a named destination
 	Store(objectPath, io.Reader) error
 	// Get returns a reader to the stored file
@@ -69,6 +73,11 @@ func NewLocalTempFSCrawlStorage() (*LocalTempFSCrawlStorage, error) {
 		return nil, err
 	}
 	return &LocalTempFSCrawlStorage{baseDir: dir}, nil
+}
+
+// Storing metadata locally is the same as storing data
+func (l *LocalTempFSCrawlStorage) StoreMetadata(name string, reader io.Reader) error {
+	return l.Store(name, reader)
 }
 
 // Store saves the contents from the reader into a file named after `object`
@@ -147,6 +156,10 @@ func (l *LocalTempFSCrawlStorage) IsEmptyDir(dir objectPath) (bool, error) {
 
 // DiscardCrawlStorage is a CrawlStorage that stores nothing and is useful for testing
 type DiscardCrawlStorage struct {
+}
+
+func (DiscardCrawlStorage) StoreMetadata(string, io.Reader) error {
+	return nil
 }
 
 func (DiscardCrawlStorage) Store(string, io.Reader) error {

--- a/internal/synchronizer/client.go
+++ b/internal/synchronizer/client.go
@@ -18,6 +18,8 @@ type SynchronizerClient struct {
 	GraphClient triplestores.GenericTriplestoreClient
 	// the client used for communicating with s3
 	S3Client *s3.MinioClientWrapper
+	// default bucket in the s3 that is used for metadata
+	metadataBucketName string
 	// default bucket in the s3 that is used for synchronization
 	syncBucketName string
 	// processor for JSON-LD operations; stored in this struct so we can
@@ -29,18 +31,19 @@ type SynchronizerClient struct {
 
 // Create a new SynchronizerClient by directly passing in the clients
 // Mainly used for testing
-func NewSynchronizerClientFromClients(graphClient triplestores.GenericTriplestoreClient, s3Client *s3.MinioClientWrapper, bucketName string) (SynchronizerClient, error) {
+func NewSynchronizerClientFromClients(graphClient triplestores.GenericTriplestoreClient, s3Client *s3.MinioClientWrapper, bucketName string, metadataBucketName string) (SynchronizerClient, error) {
 	processor, options, err := common.NewJsonldProcessor(false, nil)
 	if err != nil {
 		return SynchronizerClient{}, err
 	}
 
 	client := SynchronizerClient{
-		GraphClient:     graphClient,
-		S3Client:        s3Client,
-		syncBucketName:  bucketName,
-		jsonldProcessor: processor,
-		jsonldOptions:   options,
+		GraphClient:        graphClient,
+		S3Client:           s3Client,
+		syncBucketName:     bucketName,
+		metadataBucketName: metadataBucketName,
+		jsonldProcessor:    processor,
+		jsonldOptions:      options,
 	}
 	return client, nil
 }

--- a/internal/synchronizer/client_test.go
+++ b/internal/synchronizer/client_test.go
@@ -73,9 +73,10 @@ func (suite *SynchronizerClientSuite) SetupSuite() {
 
 	t := suite.T()
 	config := s3.MinioContainerConfig{
-		Username:      "minioadmin",
-		Password:      "minioadmin",
-		DefaultBucket: "iow",
+		Username:       "minioadmin",
+		Password:       "minioadmin",
+		DefaultBucket:  "iow",
+		MetadataBucket: "iow-metadata",
 	}
 
 	minioContainer, err := s3.NewMinioContainerFromConfig(config)
@@ -89,14 +90,14 @@ func (suite *SynchronizerClientSuite) SetupSuite() {
 		return suite.minioContainer.ClientWrapper.Client.IsOnline()
 	}, 10*time.Second, 500*time.Millisecond, "MinIO container did not become online in time")
 
-	err = suite.minioContainer.ClientWrapper.MakeDefaultBucket()
+	err = suite.minioContainer.ClientWrapper.SetupBuckets()
 	require.NoError(t, err)
 
 	graphdbContainer, err := triplestores.NewGraphDBContainer("iow", filepath.Join("triplestores", "testdata", "iow-config.ttl"))
 	suite.Require().NoError(err)
 	suite.graphdbContainer = graphdbContainer
 
-	client, err := NewSynchronizerClientFromClients(&graphdbContainer.Client, suite.minioContainer.ClientWrapper, suite.minioContainer.ClientWrapper.DefaultBucket)
+	client, err := NewSynchronizerClientFromClients(&graphdbContainer.Client, suite.minioContainer.ClientWrapper, suite.minioContainer.ClientWrapper.DefaultBucket, suite.minioContainer.ClientWrapper.MetadataBucket)
 	require.NoError(t, err)
 	suite.client = client
 }

--- a/internal/synchronizer/s3/client.go
+++ b/internal/synchronizer/s3/client.go
@@ -40,12 +40,23 @@ type MinioClientWrapper struct {
 	// Specified here to avoid having to pass it as a parameter to every operation
 	// since we are only using one bucket
 	DefaultBucket string
+
+	// A separate bucket for storing public metadata
+	// This is used so the metadata can be made
+	// public without exposing crawled data
+	MetadataBucket string
 }
 
 type S3Prefix = string
 
 // MinioConnection Set up minio and initialize client
 func NewMinioClientWrapper(mcfg config.MinioConfig) (*MinioClientWrapper, error) {
+	if mcfg.MetadataBucket == "" {
+		return nil, errors.New("no metadata bucket specified")
+	}
+	if mcfg.Bucket == "" {
+		return nil, errors.New("no bucket specified")
+	}
 
 	var endpoint string
 
@@ -77,19 +88,31 @@ func NewMinioClientWrapper(mcfg config.MinioConfig) (*MinioClientWrapper, error)
 			})
 	}
 
-	return &MinioClientWrapper{Client: minioClient, DefaultBucket: mcfg.Bucket}, err
+	return &MinioClientWrapper{Client: minioClient, DefaultBucket: mcfg.Bucket, MetadataBucket: mcfg.MetadataBucket}, err
 }
 
 // Create the default bucket
-func (m *MinioClientWrapper) MakeDefaultBucket() error {
+func (m *MinioClientWrapper) SetupBuckets() error {
 	exists, err := m.Client.BucketExists(context.Background(), m.DefaultBucket)
 	if err != nil {
 		return err
 	}
-	if exists {
-		return nil
+	if !exists {
+		if err := m.Client.MakeBucket(context.Background(), m.DefaultBucket, minio.MakeBucketOptions{}); err != nil {
+			return err
+		}
 	}
-	return m.Client.MakeBucket(context.Background(), m.DefaultBucket, minio.MakeBucketOptions{})
+
+	exists, err = m.Client.BucketExists(context.Background(), m.MetadataBucket)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := m.Client.MakeBucket(context.Background(), m.MetadataBucket, minio.MakeBucketOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Remove an object from the store
@@ -241,6 +264,11 @@ func (m *MinioClientWrapper) UploadFile(uploadPath S3Prefix, localFileName strin
 // Store bytes into the minio store
 func (m MinioClientWrapper) Store(path S3Prefix, data io.Reader) error {
 	_, err := m.Client.PutObject(context.Background(), m.DefaultBucket, path, data, -1, minio.PutObjectOptions{})
+	return err
+}
+
+func (m MinioClientWrapper) StoreMetadata(path S3Prefix, data io.Reader) error {
+	_, err := m.Client.PutObject(context.Background(), m.MetadataBucket, path, data, -1, minio.PutObjectOptions{})
 	return err
 }
 

--- a/internal/synchronizer/s3/client.go
+++ b/internal/synchronizer/s3/client.go
@@ -192,7 +192,7 @@ func (m *MinioClientWrapper) GetObjectAsBytes(objectName S3Prefix) ([]byte, erro
 
 	stat, err := fileObject.Stat()
 	if err != nil {
-		log.Infof("Issue with reading an object. Seems to not exist in bucket: %s and name: %s", m.DefaultBucket, objectName)
+		log.Errorf("Issue with reading an object. Seems to not exist in bucket: %s and name: %s", m.DefaultBucket, objectName)
 		return nil, err
 	}
 

--- a/internal/synchronizer/s3/client_test.go
+++ b/internal/synchronizer/s3/client_test.go
@@ -32,17 +32,18 @@ type S3ClientSuite struct {
 // Setup common dependencies before starting the test suite
 func (suite *S3ClientSuite) SetupSuite() {
 	config := MinioContainerConfig{
-		Username:      "minioadmin",
-		Password:      "minioadmin",
-		DefaultBucket: "gleanerbucket",
-		ContainerName: "objects_test_minio",
+		Username:       "minioadmin",
+		Password:       "minioadmin",
+		DefaultBucket:  "gleanerbucket",
+		MetadataBucket: "metadatabucket",
+		ContainerName:  "objects_test_minio",
 	}
 	minioContainer, err := NewMinioContainerFromConfig(config)
 	suite.Require().NoError(err)
 	suite.minioContainer = minioContainer
 
 	// create the bucket
-	err = suite.minioContainer.ClientWrapper.MakeDefaultBucket()
+	err = suite.minioContainer.ClientWrapper.SetupBuckets()
 	suite.Require().NoError(err)
 
 }


### PR DESCRIPTION
Add an option to specify a different bucket for metadata that way the bucket can be made public without us needing to expose all the harvest data to the internet. 