### PR TITLE
Add output path for shacl

### DIFF
--- a/shacl_validator/shacl_validator_grpc_py/cli.py
+++ b/shacl_validator/shacl_validator_grpc_py/cli.py
@@ -72,7 +72,9 @@ def main():
     generate_geoconnex_csv_subparser.add_argument(
         "--geoconnex_namespace", type=str, help="Namespace for the geoconnex csv. Example: wwdh/usace", required=True
     )
-    
+    generate_geoconnex_csv_subparser.add_argument(
+        "--output_path", type=str, help="Where to save the geoconnex csv", default="~/geoconnex.csv"
+    )
 
     args = parser.parse_args()
     graph = Graph().parse(args.shacl_file)
@@ -90,6 +92,7 @@ def main():
                 shacl_shape=args.shacl_file,
                 check_shacl=args.validate_shacl,
                 geoconnex_namespace=args.geoconnex_namespace,
+                output_path=args.output_path
             )
         )
     else:

--- a/shacl_validator/shacl_validator_grpc_py/geoconnex_gen.py
+++ b/shacl_validator/shacl_validator_grpc_py/geoconnex_gen.py
@@ -17,6 +17,7 @@ class GeoconnexCSVConfig:
     shacl_shape: Graph
     description: str
     geoconnex_namespace: str
+    output_path: str
 
 
 def generate_geoconnex_csv(config: GeoconnexCSVConfig):
@@ -57,9 +58,12 @@ def generate_geoconnex_csv(config: GeoconnexCSVConfig):
         csv_rows.append(
             [f"https://geoconnex.us/{config.geoconnex_namespace}/{feature_id}", feature_url, config.contact_email, config.description]
         )
+        break
 
-    output_path = Path("geoconnex.csv")
-    with open(output_path.absolute(), "w", newline="", encoding="utf-8") as f:
+    assert config.output_path, "output_path must be set"
+    output_path = Path(config.output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path.resolve().absolute(), "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(csv_header_row)
         writer.writerows(csv_rows)


### PR DESCRIPTION
create an output path argument when generating the geoconnex csv so it can be more cleanly mounted as a volume