### PR TITLE
Make retry timeouts non fatal

### DIFF
--- a/internal/common/http_client.go
+++ b/internal/common/http_client.go
@@ -91,12 +91,12 @@ func NewMockedClient(strictMode bool, urlToMock map[string]MockResponse) *http.C
 
 // RetryTransport implements retries and exponential backoff at the transport level
 type RetryTransport struct {
-	Base         http.RoundTripper
-	Retries      int
-	Backoff      time.Duration
-	ThrowTimeout bool
+	Base    http.RoundTripper
+	Retries int
+	Backoff time.Duration
 }
 
+// An error returned when the maximum number of retries is exceeded.
 type MaxRetryError struct {
 	Err error
 }

--- a/internal/crawl/site_test.go
+++ b/internal/crawl/site_test.go
@@ -34,6 +34,32 @@ func TestGetJsonLDWithBadMimetype(t *testing.T) {
 
 }
 
+func TestTimeout(t *testing.T) {
+
+	const dummy_domain = "http://google.com"
+
+	mockedClient := common.NewMockedClient(true, map[string]common.MockResponse{
+		dummy_domain: {
+			File:    "testdata/reference_feature.jsonld",
+			Timeout: true,
+		},
+	})
+
+	url := URL{
+		Loc: dummy_domain,
+	}
+	check := atomic.Bool{}
+	check.Store(false)
+	report, err := harvestOneSite(context.Background(), "DUMMY_SITEMAP", url, &SitemapHarvestConfig{
+		httpClient:                mockedClient,
+		storageDestination:        &storage.DiscardCrawlStorage{},
+		checkExistenceBeforeCrawl: &check,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, report.nonFatalError.Status)
+	require.Contains(t, report.nonFatalError.Message, "timeout")
+}
+
 func TestHarvestOneSite(t *testing.T) {
 
 	const dummy_domain = "http://google.com"


### PR DESCRIPTION
Previously sources which lagged and didn't resolve to give us a status code (i.e 400) would stop the pipeline. This PR changes that to be non fatal so the rest of the crawl continues to proceed.

<img width="2335" height="885" alt="image" src="https://github.com/user-attachments/assets/130983e9-a296-456f-813c-9492d143b599" />

`Get "https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items/TEST": failed to get a successful response from https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items/TEST after 3 retries: <nil>`