### PR TITLE
Change shacl log level

### DIFF
--- a/internal/crawl/site.go
+++ b/internal/crawl/site.go
@@ -195,7 +195,6 @@ func harvestOneSite(ctx context.Context, sitemapId string, url URL, config *Site
 		err = validate_shacl(ctx, *config.grpcClient, url.Loc, string(jsonld))
 		if err != nil {
 			if shaclErr, ok := err.(ShaclValidationFailureError); ok {
-				log.Errorf("Failure for %s: %s", url.Loc, shaclErr.ShaclErrorMessage)
 				result_metadata.warning = pkg.ShaclInfo{
 					ShaclStatus:            pkg.ShaclInvalid,
 					ShaclValidationMessage: shaclErr.ShaclErrorMessage,
@@ -209,8 +208,8 @@ func harvestOneSite(ctx context.Context, sitemapId string, url URL, config *Site
 				// validation mode wherein we fail fast upon shacl non-compliance
 				// however, we do allow a flag to exit and strictly fail
 				if config.exitOnShaclFailure {
-					log.Debugf("Returning early on shacl failure for %s", url.Loc)
-					return result_metadata, fmt.Errorf("exiting early with shacl failure %s", shaclErr.ShaclErrorMessage)
+					log.Errorf("Returning early on shacl failure for %s with message %s", url.Loc, shaclErr.ShaclErrorMessage)
+					return result_metadata, fmt.Errorf("exiting early for %s with shacl failure %s", url.Loc, shaclErr.ShaclErrorMessage)
 				}
 			} else {
 				return result_metadata, fmt.Errorf("failed to communicate with shacl validation service when harvesting %s: %w", url.Loc, err)

--- a/internal/crawl/sitemap.go
+++ b/internal/crawl/sitemap.go
@@ -208,7 +208,7 @@ func (s *Sitemap) Harvest(ctx context.Context, config *SitemapHarvestConfig) (pk
 			if !result_metadata.warning.IsNil() {
 				shaclFailuresSoFar := sitesWithShaclFailures.Load()
 				if shaclFailuresSoFar < int32(config.maxShaclErrorsToStore) {
-					log.Errorf("Shacl validation failed for %s: %s", url, result_metadata.warning)
+					log.Errorf("Shacl validation failed for %s: %s", url.Loc, result_metadata.warning)
 					s.warningMu.Lock()
 					s.warnings = append(s.warnings, result_metadata.warning)
 					s.warningMu.Unlock()

--- a/internal/crawl/sitemap.go
+++ b/internal/crawl/sitemap.go
@@ -208,9 +208,12 @@ func (s *Sitemap) Harvest(ctx context.Context, config *SitemapHarvestConfig) (pk
 			if !result_metadata.warning.IsNil() {
 				shaclFailuresSoFar := sitesWithShaclFailures.Load()
 				if shaclFailuresSoFar < int32(config.maxShaclErrorsToStore) {
+					log.Errorf("Shacl validation failed for %s: %s", url, result_metadata.warning)
 					s.warningMu.Lock()
 					s.warnings = append(s.warnings, result_metadata.warning)
 					s.warningMu.Unlock()
+				} else if shaclFailuresSoFar == int32(config.maxShaclErrorsToStore) {
+					log.Warnf("Too many shacl errors for %s. Skipping further errors to prevent log spam", s.sitemapId)
 				}
 				if result_metadata.warning.ShaclStatus == pkg.ShaclInvalid {
 					sitesWithShaclFailures.Store(
@@ -283,6 +286,8 @@ func (s *Sitemap) Harvest(ctx context.Context, config *SitemapHarvestConfig) (pk
 	}
 
 	log.Debugf("Finished crawling sitemap %s in %f seconds", s.sitemapId, stats.SecondsToComplete)
+
+	log.Infof("Sitemap %s had %d successful urls, %d non fatal crawl errors, and %d shacl issues", s.sitemapId, len(successfulUrls), len(stats.CrawlFailures), stats.WarningStats.TotalShaclFailures)
 
 	return stats, err
 }


### PR DESCRIPTION
Only log shacl validation failure as an error if the user wants to fail early on it. Otherwise it is stored as an non essential error. The reason being for this is that log spam can slow down dagster UI