### PR TITLE
Increase grpc size

### DIFF
--- a/internal/crawl/sitemap.go
+++ b/internal/crawl/sitemap.go
@@ -102,11 +102,11 @@ func NewSitemapHarvestConfig(httpClient *http.Client, sitemap *Sitemap, shaclAdd
 	var grpcClient protoBuild.ShaclValidatorClient
 	// shacl validation is optional
 	if shaclAddress != "" {
-		// 8 megabytes is the current upperbound of the jsonld documents we will validate
+		// 32 megabytes is the current upperbound of the jsonld documents we will validate
 		// beyond that is a sign that the document may be too large or incorrectly formatted
-		eightMegabytes := 8 * 1024 * 1024
+		thirtyTwoMB := 32 * 1024 * 1024
 		conn, err := grpc.NewClient(shaclAddress,
-			grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithMaxHeaderListSize(uint32(eightMegabytes)),
+			grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithMaxHeaderListSize(uint32(thirtyTwoMB)),
 		)
 		if err != nil {
 			return SitemapHarvestConfig{}, fmt.Errorf("failed to connect to gRPC server: %w", err)

--- a/shacl_validator/shacl_validator_grpc_py/server.py
+++ b/shacl_validator/shacl_validator_grpc_py/server.py
@@ -28,7 +28,7 @@ from lib import validate_graph
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-MAX_MESSAGE_SIZE = 8 * 1024 * 1024  # 8 MB in bytes
+MAX_MESSAGE_SIZE = 32 * 1024 * 1024  # 32 MB in bytes
 
 class ShaclValidator(shacl_validator_pb2_grpc.ShaclValidatorServicer):
 


### PR DESCRIPTION
There are some extremely large JSON-LD documents that are over 32 mb in size. As such, I have made the max size of the grpc payload up to 32mb. It is a bit annoying that this even needs to be configured, but it is a decent security provision to make sure that we aren't accidentally passing huge payloads accidentally