### PR TITLE
Safer memory in wasm

### DIFF
--- a/shacl_validator/shacl_validator_grpc_rs/wasm_exportable_lib/src/lib.rs
+++ b/shacl_validator/shacl_validator_grpc_rs/wasm_exportable_lib/src/lib.rs
@@ -41,9 +41,7 @@ pub async fn validate_jsonld_against_geoconnex_schema(jsonld: String) -> String 
             Ok(report) => report.to_string(),
             Err(err) => err.to_string(),
         },
-        Err(err) => {
-            return err.to_string();
-        }
+        Err(err) => err.to_string(),
     }
 }
 


### PR DESCRIPTION
I have been having an issue in wasm where it says unreachable error signifying there is a memory issue. I am not entirety clear why but figured I should be taking ownership of the string and not using any unwraps.

also added another function for getting the embedded ttl schema