### PR TITLE
Fix hash check issue

### DIFF
--- a/cmd/nabu/test.go
+++ b/cmd/nabu/test.go
@@ -29,9 +29,13 @@ func Test(ctx context.Context, client *synchronizer.SynchronizerClient) error {
 		return err
 	}
 
-	md5Hash, err := client.S3Client.GetHash("test")
+	md5Hash, exists, err := client.S3Client.GetHash("test")
 	if err != nil {
 		return fmt.Errorf("failed to get hash: %w", err)
+	}
+
+	if !exists {
+		return fmt.Errorf("the file does not exist")
 	}
 
 	calculatedHash := md5.Sum(testData)

--- a/internal/crawl/hash_checks/hash_check.go
+++ b/internal/crawl/hash_checks/hash_check.go
@@ -96,11 +96,20 @@ func (hc *hashChecker) CheckIfAlreadyExists(url url_info.URL, sitemapId string) 
 		ServerProvidedHash: true,
 	}
 
-	expectedLocationInStorage = "summoned/" + sitemapId + "/" + remoteHash + ".jsonld"
-	storageHash, err := hc.storage.GetHash(expectedLocationInStorage)
+	// the location in storage is the base64 encoded URL with .jsonld extension
+	expectedLocationInStorage = "summoned/" + sitemapId + "/" + url.Base64Loc + ".jsonld"
+	storageHash, file_exists, err := hc.storage.GetHash(expectedLocationInStorage)
 	if err != nil {
 		return hashCheckMetadata, err
 	}
+	if !file_exists {
+		log.Tracef("%s does not exist in %s", expectedLocationInStorage, "storage")
+		return HashCheckResult{
+			ServerProvidedHash: true,
+			FileAlreadyExists:  false,
+		}, nil
+	}
+
 	if storageHash == remoteHash {
 		log.Tracef("skipping %s because it already exists in %s", url.Loc, expectedLocationInStorage)
 		hashCheckMetadata.PathInStorage = expectedLocationInStorage

--- a/internal/crawl/site.go
+++ b/internal/crawl/site.go
@@ -88,6 +88,7 @@ func harvestOnePID(ctx context.Context, sitemapId string, url url_info.URL, conf
 		}
 		result_metadata.serverHadHash = result.ServerProvidedHash
 		result_metadata.pathInStorage = result.PathInStorage
+		log.Tracef("%s already exists result: %+v", url.Loc, result)
 		if result.FileAlreadyExists {
 			return result_metadata, nil
 		}

--- a/internal/crawl/storage/discard_storage.go
+++ b/internal/crawl/storage/discard_storage.go
@@ -40,6 +40,6 @@ func (DiscardCrawlStorage) IsEmptyDir(ObjectPath) (bool, error) {
 	return true, nil
 }
 
-func (DiscardCrawlStorage) GetHash(string) (Md5Hash, error) {
-	return "", nil
+func (DiscardCrawlStorage) GetHash(string) (Md5Hash, bool, error) {
+	return "", false, nil
 }

--- a/internal/crawl/storage/storage.go
+++ b/internal/crawl/storage/storage.go
@@ -58,7 +58,7 @@ type CrawlStorage interface {
 	// IsEmptyDir returns true if the directory is empty
 	IsEmptyDir(ObjectPath) (bool, error)
 	// Get the hash of the file
-	GetHash(ObjectPath) (Md5Hash, error)
+	GetHash(ObjectPath) (hash Md5Hash, file_exists bool, err error)
 }
 
 // Given a storage path, iterate through it and remove any files that aren't in sitesToKeep

--- a/internal/crawl/storage/tempfs_storage.go
+++ b/internal/crawl/storage/tempfs_storage.go
@@ -115,6 +115,6 @@ func (l *LocalTempFSCrawlStorage) IsEmptyDir(dir ObjectPath) (bool, error) {
 	return len(files) == 0, nil
 }
 
-func (l *LocalTempFSCrawlStorage) GetHash(object string) (Md5Hash, error) {
-	return "", nil
+func (l *LocalTempFSCrawlStorage) GetHash(object string) (Md5Hash, bool, error) {
+	return "", true, nil
 }

--- a/internal/synchronizer/s3/client_test.go
+++ b/internal/synchronizer/s3/client_test.go
@@ -534,9 +534,10 @@ func (suite *S3ClientSuite) TestGetMD5HashServerside() {
 	md5String := fmt.Sprintf("%x", md5.Sum(data))
 	err := suite.minioContainer.ClientWrapper.StoreWithHash(prefix+"test", bytes.NewReader(data), len(data))
 	suite.Require().NoError(err)
-	hash, err := suite.minioContainer.ClientWrapper.GetHash(prefix + "test")
+	hash, exists, err := suite.minioContainer.ClientWrapper.GetHash(prefix + "test")
 	suite.Require().NoError(err)
 	suite.Require().Equal(md5String, hash)
+	suite.Require().True(exists)
 
 	suite.T().Run("catches bad hash from multipart upload", func(t *testing.T) {
 		const undefinedSize = -1
@@ -544,8 +545,9 @@ func (suite *S3ClientSuite) TestGetMD5HashServerside() {
 		err := suite.minioContainer.ClientWrapper.StoreWithHash(prefix+"testNoHash", bytes.NewReader(data), undefinedSize)
 		suite.Require().NoError(err)
 
-		_, err = suite.minioContainer.ClientWrapper.GetHash(prefix + "testNoHash")
+		_, file_exists, err := suite.minioContainer.ClientWrapper.GetHash(prefix + "testNoHash")
 		suite.Require().Error(err)
+		suite.Require().True(file_exists)
 	})
 
 }


### PR DESCRIPTION
Previously a fatal error was being generated if no hash was present in the remote server. This should instead be a non fatal error that can be caught and treated make sure it treats it as if the file hash doesnt match