### PR TITLE
Fix nquad channel closing operation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,15 @@
 {
     "configurations": [
         {
+            // requires the go binary to be compiled with proper debug support'
+            // see the makefile in the root for such a compilation method
+            "name": "Attach to Go Binary",
+            "type": "go",
+            "request": "attach",
+            "mode": "local",
+            "processId": "nabu"
+        },
+        {
             "name": "Debug Shacl Validation",
             "type": "go",
             "request": "launch",

--- a/cmd/nabu/main.go
+++ b/cmd/nabu/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime/trace"
 	"strings"
+	"time"
 
 	"github.com/internetofwater/nabu/internal/common"
 	"github.com/internetofwater/nabu/internal/common/projectpath"
@@ -132,6 +133,12 @@ func (n NabuRunner) Run(ctx context.Context, client *http.Client) (harvestReport
 
 	if err := setupLogging(n.args.LogLevel, n.args.LogAsJson); err != nil {
 		log.Fatal(err)
+	}
+
+	if n.args.LogLevel == "DEBUG" {
+		log.Debug("Sleeping to allow for time for debugger to attach")
+		time.Sleep(3 * time.Second)
+		log.Debug("Finished sleeping")
 	}
 
 	if n.args.UseOtel || n.args.OtelEndpoint != "" {

--- a/makefile
+++ b/makefile
@@ -70,3 +70,6 @@ checkMaxTcpConnectionsPerProcess:
 tools:
 	go install gotest.tools/gotestsum@latest
 	sudo apt install -y protobuf-compiler
+
+build_for_debug:
+	go build -gcflags="all=-N -l" -o nabu ./cmd/nabu


### PR DESCRIPTION
Previously the channel was not clocking is there was an issue with the nquad files such as no data in the prefix. This could make the system block indefinitely waiting for data.

Also should log if the error arises for better debugging.