### PR TITLE
Update mainstem lookup to v3

### DIFF
--- a/shacl_validator/data/.env.example
+++ b/shacl_validator/data/.env.example
@@ -1,0 +1,3 @@
+# To upload oci artifacts to github using oras you need to set a classic personal access token
+# with repo and packages scopes
+GITHUB_TOKEN=ghp_

--- a/shacl_validator/data/join.py
+++ b/shacl_validator/data/join.py
@@ -10,7 +10,7 @@
 This file joins together all catchments and
 flowlines into a single file in such a way that
 each row can be queried to get the associated
-catchment, flowline, and mainstem.
+catchment and mainstem.
 """
 
 from pathlib import Path
@@ -21,65 +21,46 @@ import pandas as pd
 reference_catchments = Path(__file__).parent / "reference_catchments.gpkg"
 assert reference_catchments.exists(), "reference_catchments.gpkg not found; you must download it from sciencebase"
 
-reference_flowline = Path(__file__).parent / "reference_flowline.gpkg"
-assert reference_flowline.exists(), "reference_flowline.gpkg not found; you must download it from sciencebase"
-
-print("Reading reference catchments and flowlines")
+print("Reading reference catchments")
 catchments = gpd.read_file(reference_catchments)
 catchments = catchments.to_crs(4326)
 # We add a prefix so that the column names are unique
 # and easier to understand after the join
 catchments = catchments.add_prefix("Catchment_")
 
-flowlines = gpd.read_file(reference_flowline)
-flowlines = flowlines.to_crs(4326)
-flowlines = flowlines.add_prefix("Flowline_")
-
-print("Joining catchments and flowlines")
-catchments_with_associated_flowline = catchments.merge(
-    flowlines,
-    left_on="Catchment_featureid",
-    right_on="Flowline_COMID",
-    how="left",
-)
-
 print("Loading mainstem lookup csv file")
 # The mainstem lookup file is from the internet of water
 # csv release; it needs to be cast to an integer 
 # for the join since the original type is a string
 mainstem_lookup = pd.read_csv(
-    "https://github.com/internetofwater/ref_rivers/releases/download/V3/lpv3_lookup.csv",
-    dtype={"lp_mainstem_v3": "Int64", "uri": "string"},
+    "https://github.com/internetofwater/ref_rivers/releases/download/V3/nhdpv2_lookup.csv",
+    dtype={"comid": "Int64", "uri": "string"},
 )
 mainstem_lookup = mainstem_lookup.add_prefix("Mainstem_Metadata_")
 
-print("Joining catchments, flowlines, and mainstem lookup")
-final = catchments_with_associated_flowline.merge(
+print("Joining catchments and mainstem lookup file")
+final = catchments.merge(
     mainstem_lookup,
-    # LevelPathI == The LevelPath identifier. This groups together a set of flowlines that form a single mainstem path.
-    # All lines with the same LevelPathI form one continuous routed path (e.g., the entire main stem of a river).
-    left_on="Flowline_LevelPathI",
-    right_on="Mainstem_Metadata_lp_mainstem_v3",
+    left_on="Catchment_featureid",
+    # join the comid column from the csv with the catchments; we don't
+    # need to use the nhd plus flowlines at all since the CSV already provides the lookup comid
+    right_on="Mainstem_Metadata_comid",
     how="left",
 ).rename(columns={"Mainstem_Metadata_uri": "geoconnex_url"})
 
-# We  drop the flowline geometry since it isn't needed in the final
-# result and would make our file larger and have a second geometry
-# column; flatgeobuf can't index on multiple geometry columns
-# so we only keep the catchment geometry that we actually need for the lookup;
-# The mainstem geometry can be retrieved from the geoconnex reference
-# server
-final = final.drop(columns="Flowline_geometry")
-final.to_file("reference_catchments_and_flowlines.fgb")
+# drop the mainstem comid column since it is the same as the catchment feature id
+final.drop(columns=["Mainstem_Metadata_comid"], inplace=True)
 
 # Ensure that the final result has a few of the expected columns from each of the data sources
 # we don't check every column but it must have at least these so its a good enough check
 assert "geoconnex_url" in final.columns
-assert "Flowline_COMID" in final.columns
 assert "Catchment_featureid" in final.columns
+assert "Mainstem_Metadata_comid" not in final.columns
 
 percent_catchments_without_geoconnex_mainstem_url = final["geoconnex_url"].isna().mean() * 100
 
 print(f"Percentage of catchments without geoconnex mainstem url: {percent_catchments_without_geoconnex_mainstem_url}")
 
+print("Writing file to disk")
+final.to_file("reference_catchments_and_flowlines.fgb")
 print("Finished successfully")

--- a/shacl_validator/data/makefile
+++ b/shacl_validator/data/makefile
@@ -1,6 +1,8 @@
 ORAS_CACHE := $(CURDIR)/.oras/cache
 export ORAS_CACHE
 
+include .env
+
 # To run this you must have the gpkg files which be downloaded from
 # https://www.sciencebase.gov/catalog/item/61295190d34e40dd9c06bcd7
 generate_flatgeobuf:
@@ -10,11 +12,9 @@ pull_mainstem_flatgeobuf:
 	oras pull ghcr.io/internetofwater/reference_catchments_and_flowlines:latest
 
 backup_mainstem_flatgeobuf:
-	@echo -n "Enter your GitHub token: "; \
-	read GITHUB_TOKEN; \
-	oras push ghcr.io/internetofwater/reference_catchments_and_flowlines:latest reference_catchments_and_flowlines.fgb:application/octet-stream \
+	echo ${GITHUB_TOKEN} | oras push ghcr.io/internetofwater/reference_catchments_and_flowlines:latest reference_catchments_and_flowlines.fgb:application/octet-stream \
 		--username internetofwater \
-		--password "$$GITHUB_TOKEN" \
+		--password-stdin \
 		--annotation 'org.opencontainers.image.source=https://github.com/internetofwater/nabu' \
 		--annotation 'org.opencontainers.image.description=The flatgeobuf files containing all the data from the Reference Hydrofabric here: https://www.sciencebase.gov/catalog/item/61295190d34e40dd9c06bcd7'
 


### PR DESCRIPTION
In the geoconnex pipeline we need a file where each row maps a catchment to the associated geoconnex mainstem. This allows us to add mainstem indentifiers to features that don't provide them in the original dataset by finding which catchment intersects with a feature's geometry.

This also allows us to power the web application here for mainstem / catchment exploration
https://docs.geoconnex.us/playground/mainstems

I am working on updating this from the older v2.1 csv to the new v3 csv. 

~~Note that we need to wait to merge this. For some reason many of the catchments don't have associated geoconnex mainstems~~