### PR TITLE
Upload stats for bulk integrations

### DIFF
--- a/crawl-status-page/src/generated_types.ts
+++ b/crawl-status-page/src/generated_types.ts
@@ -103,11 +103,11 @@ export interface SitemapCrawlStats {
    */
   SitesInSitemap: number /* int */;
   /**
-   * Whether the sitemap appears to be down based on the crawl results
+   * Whether the datset in the sitemap appears to be down based on the crawl results
    * An API specified in a given sitemap is assumed to be down if the first ~20 sites
    * all failed without a single successful harvest
    */
-  SitemapDown: boolean;
+  DatasetDown: boolean;
 }
 /**
  * A sitemap index is just a list of sitemaps and thus

--- a/internal/crawl/sitemap.go
+++ b/internal/crawl/sitemap.go
@@ -91,7 +91,7 @@ type SitemapHarvestConfig struct {
 	cleanupOutdatedJsonld bool
 	// the number of failed sites in a row before we exit
 	// and assume the sitemap is down
-	failedSitesToAssumeSitemapDown int
+	failedSitesToAssumeDatasetDown int
 }
 
 // Make a new SiteHarvestConfig with all the clients and config
@@ -132,7 +132,7 @@ func NewSitemapHarvestConfig(httpClient *http.Client, sitemap *Sitemap, shaclGRP
 		// currently hard coded. could be configurable in the future
 		maxShaclErrorsToStore: 20,
 		// currently hard coded. could be configurable in the future
-		failedSitesToAssumeSitemapDown: 20,
+		failedSitesToAssumeDatasetDown: 20,
 	}, nil
 }
 
@@ -163,16 +163,35 @@ func (s *Sitemap) Harvest(ctx context.Context, config *SitemapHarvestConfig) (pk
 		return pkg.SitemapCrawlStats{}, nil, err
 	}
 
+	var stats pkg.SitemapCrawlStats
+	var err error
+	var cleanedUpFilesNames []string
 	if s.isBulkSitemap {
-		return s.HarvestBulkSitemap(ctx, config)
+		stats, err = s.HarvestBulkSitemap(ctx, config)
+		// bulk doesn't do cleanup
+		cleanedUpFilesNames = []string{}
 	} else {
-		return s.HarvestPIDsSitemap(ctx, config)
+		stats, cleanedUpFilesNames, err = s.HarvestPIDsSitemap(ctx, config)
 	}
+	if err != nil {
+		log.Errorf("Error harvesting sitemap %s: %s", s.sitemapId, err)
+		return stats, cleanedUpFilesNames, err
+	}
+
+	asJson, err := stats.ToJsonIoReader()
+	if err != nil {
+		return pkg.SitemapCrawlStats{}, nil, err
+	}
+	err = s.storageDestination.StoreMetadata(fmt.Sprintf("metadata/sitemaps/%s.json", s.sitemapId), asJson)
+	if err != nil {
+		return pkg.SitemapCrawlStats{}, nil, err
+	}
+	return stats, cleanedUpFilesNames, err
 }
 
 // Harvest all the URLs in the given sitemap and return the associated metadata as well as a list
 // of sites that were cleaned up after harvesting
-func (s *Sitemap) HarvestPIDsSitemap(ctx context.Context, config *SitemapHarvestConfig) (pkg.SitemapCrawlStats, []string, error) {
+func (s *Sitemap) HarvestPIDsSitemap(ctx context.Context, config *SitemapHarvestConfig) (crawlStats pkg.SitemapCrawlStats, cleanedUpFileNames []string, err error) {
 	ctx, span := opentelemetry.SubSpanFromCtxWithName(ctx, fmt.Sprintf("sitemap_harvest_%s", s.sitemapId))
 	defer span.End()
 
@@ -182,7 +201,7 @@ func (s *Sitemap) HarvestPIDsSitemap(ctx context.Context, config *SitemapHarvest
 	start := time.Now()
 	log.Infof("Harvesting sitemap %s with %d urls", s.sitemapId, len(s.URL))
 
-	sitemapStatusTracker := NewSitemapStatusTracker(config.failedSitesToAssumeSitemapDown)
+	sitemapStatusTracker := NewSitemapStatusTracker(config.failedSitesToAssumeDatasetDown)
 
 	successfulSitesMu := sync.Mutex{}
 	// includes both sites that were download
@@ -219,7 +238,7 @@ func (s *Sitemap) HarvestPIDsSitemap(ctx context.Context, config *SitemapHarvest
 		group.Go(func() error {
 			if sitemapStatusTracker.AppearsDown() {
 				return &SitemapAppearsDownError{
-					message: fmt.Sprintf("Returning early since %d failures were detected without a single successful harvest; the sitemap is assumed to be down or had a change in the underlying API", config.failedSitesToAssumeSitemapDown),
+					message: fmt.Sprintf("Returning early since %d failures were detected without a single successful harvest; the sitemap is assumed to be down or had a change in the underlying API", config.failedSitesToAssumeDatasetDown),
 				}
 			}
 
@@ -295,7 +314,7 @@ func (s *Sitemap) HarvestPIDsSitemap(ctx context.Context, config *SitemapHarvest
 			ShaclWarnings:      s.warnings,
 		},
 		CrawlFailures: s.nonFatalErrors,
-		SitemapDown:   sitemapStatusTracker.AppearsDown(),
+		DatasetDown:   sitemapStatusTracker.AppearsDown(),
 	}
 
 	if err != nil {
@@ -315,15 +334,6 @@ func (s *Sitemap) HarvestPIDsSitemap(ctx context.Context, config *SitemapHarvest
 		}
 	} else {
 		log.Warnf("Skipping old JSON-LD cleanups. It is possible %s will contain outdated JSON-LD files", "summoned/"+s.sitemapId)
-	}
-
-	asJson, err := stats.ToJsonIoReader()
-	if err != nil {
-		return pkg.SitemapCrawlStats{}, nil, err
-	}
-	err = s.storageDestination.StoreMetadata(fmt.Sprintf("metadata/sitemaps/%s.json", s.sitemapId), asJson)
-	if err != nil {
-		return pkg.SitemapCrawlStats{}, nil, err
 	}
 
 	log.Infof("Finished crawling sitemap %s in %f seconds", s.sitemapId, stats.SecondsToComplete)

--- a/internal/crawl/sitemap_bulk.go
+++ b/internal/crawl/sitemap_bulk.go
@@ -29,7 +29,7 @@ import (
 )
 
 // HarvestBulkSitemap processes a bulk sitemap by pulling and running Docker images specified as sitemap URLs.
-func (s *Sitemap) HarvestBulkSitemap(ctx context.Context, config *SitemapHarvestConfig) (pkg.SitemapCrawlStats, []string, error) {
+func (s *Sitemap) HarvestBulkSitemap(ctx context.Context, config *SitemapHarvestConfig) (pkg.SitemapCrawlStats, error) {
 
 	if config.workers != 1 {
 		log.Warn("Bulk sitemaps do not allow for specifying workers, using default worker count")
@@ -44,7 +44,7 @@ func (s *Sitemap) HarvestBulkSitemap(ctx context.Context, config *SitemapHarvest
 
 	dockerClient, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation())
 	if err != nil {
-		return pkg.SitemapCrawlStats{}, []string{}, err
+		return pkg.SitemapCrawlStats{}, err
 	}
 	defer func() { _ = dockerClient.Close() }()
 
@@ -283,5 +283,5 @@ func (s *Sitemap) HarvestBulkSitemap(ctx context.Context, config *SitemapHarvest
 		CrawlFailures: []pkg.UrlCrawlError{},
 	}
 
-	return stats, []string{}, errGroupError
+	return stats, errGroupError
 }

--- a/internal/crawl/sitemap_test.go
+++ b/internal/crawl/sitemap_test.go
@@ -6,6 +6,7 @@ package crawl
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -108,7 +109,10 @@ func TestHarvestSitemap(t *testing.T) {
 			},
 		})
 
-	sitemap, err := NewSitemap(context.Background(), mockedClient, "https://geoconnex.us/sitemap/iow/wqp/stations__5.xml", 1, &storage.DiscardCrawlStorage{}, "test")
+	storage, err := storage.NewLocalTempFSCrawlStorage()
+	require.NoError(t, err)
+
+	sitemap, err := NewSitemap(context.Background(), mockedClient, "https://geoconnex.us/sitemap/iow/wqp/stations__5.xml", 1, storage, "test")
 	require.NoError(t, err)
 
 	config, err := NewSitemapHarvestConfig(mockedClient, sitemap, nil, false, false)
@@ -119,6 +123,18 @@ func TestHarvestSitemap(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, results.SuccessfulSites, 3)
+
+	// ensure that the stats are uploaded to the storage dir
+	data, err := storage.Get("metadata/sitemaps/test.json")
+	require.NoError(t, err)
+	statsAsBytes, err := io.ReadAll(data)
+	require.NoError(t, err)
+	var statsAsJson map[string]interface{}
+	err = json.Unmarshal(statsAsBytes, &statsAsJson)
+	require.NoError(t, err)
+	require.Equal(t, statsAsJson["SitemapSourceLink"], "https://geoconnex.us/sitemap/iow/wqp/stations__5.xml")
+	require.Equal(t, statsAsJson["SitemapName"], "test")
+	require.Equal(t, statsAsJson["DatasetDown"], false)
 }
 
 func TestHarvestTwiceOverridesFile(t *testing.T) {
@@ -392,7 +408,7 @@ func TestHarvestSitemapThatIsDown(t *testing.T) {
 	config, err := NewSitemapHarvestConfig(mockedClient, sitemap, nil, false, cleanupOldJsonld)
 	require.NoError(t, err)
 
-	config.failedSitesToAssumeSitemapDown = 1
+	config.failedSitesToAssumeDatasetDown = 1
 
 	stats, _, err := sitemap.
 		Harvest(context.Background(), &config)

--- a/pkg/stats.go
+++ b/pkg/stats.go
@@ -90,10 +90,10 @@ type SitemapCrawlStats struct {
 	SuccessfulSites int
 	// The number of total sites in the sitemap
 	SitesInSitemap int
-	// Whether the sitemap appears to be down based on the crawl results
+	// Whether the datset in the sitemap appears to be down based on the crawl results
 	// An API specified in a given sitemap is assumed to be down if the first ~20 sites
 	// all failed without a single successful harvest
-	SitemapDown bool
+	DatasetDown bool
 }
 
 // Serialize the sitemap crawl stats to json


### PR DESCRIPTION
Previously nabu was not uploading crawl stats for bulk integrations. This makes stats always get uploaded regardless of integration type