### PR TITLE
Dont set catchments file for shacl service

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,10 +28,14 @@ resource "google_cloud_run_v2_service" "shacl_service" {
       resources {
         limits = {
           cpu    = "1"
-          memory = "128Mi"
+          memory = "256Mi"
         }
         # Determines whether CPU is only allocated during requests
         cpu_idle = true
+      }
+      env {
+        name  = "CATCHMENTS_FILE"
+        value = ""
       }
     }
   }


### PR DESCRIPTION
causes oom issues; we dont actually care about that since this is just used for browser validation via the docs page. we dont do mainstem stuff in that deployment